### PR TITLE
Refactor and change moving cursor to crosshair if there is a retaining action

### DIFF
--- a/libs/commons/src/main/kotlin/mono/common/MouseCursor.kt
+++ b/libs/commons/src/main/kotlin/mono/common/MouseCursor.kt
@@ -1,0 +1,16 @@
+package mono.common
+
+/**
+ * A class for enumerating all in-use mouse cursors.
+ */
+enum class MouseCursor(val value: String) {
+    DEFAULT("default"),
+    CROSSHAIR("crosshair"),
+    MOVE("move"),
+    RESIZE_NWSE("nwse-resize"),
+    RESIZE_NS("ns-resize"),
+    RESIZE_NESW("nesw-resize"),
+    RESIZE_EW("ew-resize"),
+    RESIZE_ROW("row-resize"),
+    RESIZE_COL("col-resize")
+}

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
@@ -1,6 +1,7 @@
 package mono.html.canvas
 
 import kotlinx.dom.addClass
+import mono.common.MouseCursor
 import mono.graphics.board.MonoBoard
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Point
@@ -146,8 +147,8 @@ class CanvasViewController(
         drawingInfoController.setSize(widthPx, heightPx)
     }
 
-    fun setMouseCursor(mouseCursor: String) {
-        container.style.cursor = mouseCursor
+    fun setMouseCursor(mouseCursor: MouseCursor) {
+        container.style.cursor = mouseCursor.value
     }
 
     fun toXPx(column: Double): Double = drawingInfo.toXPx(column)

--- a/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/InteractionPoint.kt
+++ b/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/InteractionPoint.kt
@@ -1,5 +1,6 @@
 package mono.shapebound
 
+import mono.common.MouseCursor
 import mono.graphics.geo.Point
 import mono.graphics.geo.Rect
 import mono.shape.shape.Line
@@ -13,7 +14,7 @@ sealed class InteractionPoint(
     val shapeId: String,
     val left: Double,
     val top: Double,
-    val mouseCursor: String
+    val mouseCursor: MouseCursor
 )
 
 /**
@@ -23,7 +24,7 @@ sealed class ScaleInteractionPoint(
     shapeId: String,
     left: Double,
     top: Double,
-    mouseCursor: String
+    mouseCursor: MouseCursor
 ) : InteractionPoint(shapeId, left, top, mouseCursor) {
     abstract fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect
 
@@ -31,7 +32,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "nwse-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NWSE) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(newPoint.left, newPoint.top, currentBound.right, currentBound.bottom)
     }
@@ -40,7 +41,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "ns-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NS) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(currentBound.left, newPoint.top, currentBound.right, currentBound.bottom)
     }
@@ -49,7 +50,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "nesw-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NESW) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(currentBound.left, newPoint.top, newPoint.left, currentBound.bottom)
     }
@@ -58,7 +59,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "ew-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_EW) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(newPoint.left, currentBound.top, currentBound.right, currentBound.bottom)
     }
@@ -67,7 +68,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "ew-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_EW) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(currentBound.left, currentBound.top, newPoint.left, currentBound.bottom)
     }
@@ -76,7 +77,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "nesw-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NESW) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(newPoint.left, currentBound.top, currentBound.right, newPoint.top)
     }
@@ -85,7 +86,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "ns-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NS) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(currentBound.left, currentBound.top, currentBound.right, newPoint.top)
     }
@@ -94,7 +95,7 @@ sealed class ScaleInteractionPoint(
         shapeId: String,
         left: Double,
         top: Double
-    ) : ScaleInteractionPoint(shapeId, left, top, "nwse-resize") {
+    ) : ScaleInteractionPoint(shapeId, left, top, MouseCursor.RESIZE_NWSE) {
         override fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect =
             Rect.byLTRB(currentBound.left, currentBound.top, newPoint.left, newPoint.top)
     }
@@ -107,7 +108,7 @@ sealed class LineInteractionPoint(
     shapeId: String,
     left: Double,
     top: Double,
-    mouseCursor: String
+    mouseCursor: MouseCursor
 ) : InteractionPoint(shapeId, left, top, mouseCursor) {
 
     class Anchor(
@@ -115,7 +116,7 @@ sealed class LineInteractionPoint(
         val anchor: Line.Anchor,
         left: Double,
         top: Double
-    ) : LineInteractionPoint(shapeId, left, top, "move")
+    ) : LineInteractionPoint(shapeId, left, top, MouseCursor.MOVE)
 
     class Edge(
         shapeId: String,
@@ -123,5 +124,10 @@ sealed class LineInteractionPoint(
         left: Double,
         top: Double,
         isHorizontal: Boolean
-    ) : LineInteractionPoint(shapeId, left, top, if (isHorizontal) "row-resize" else "col-resize")
+    ) : LineInteractionPoint(
+        shapeId,
+        left,
+        top,
+        if (isHorizontal) MouseCursor.RESIZE_ROW else MouseCursor.RESIZE_COL
+    )
 }

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -1,6 +1,7 @@
 package mono.state
 
 import mono.bitmap.manager.MonoBitmapManager
+import mono.common.MouseCursor
 import mono.common.currentTimeMillis
 import mono.common.post
 import mono.environment.Build
@@ -208,13 +209,13 @@ class MainStateManager(
         val mouseCursor = when (mousePointer) {
             is MousePointer.Move -> {
                 val interactionPoint = canvasManager.getInteractionPoint(mousePointer.pointPx)
-                interactionPoint?.mouseCursor ?: "default"
+                interactionPoint?.mouseCursor ?: MouseCursor.DEFAULT
             }
             is MousePointer.Drag -> {
                 val mouseCommand = currentMouseCommand
-                if (mouseCommand != null) mouseCommand.mouseCursor else "default"
+                if (mouseCommand != null) mouseCommand.mouseCursor else MouseCursor.DEFAULT
             }
-            is MousePointer.Up -> "default"
+            is MousePointer.Up -> MouseCursor.DEFAULT
 
             MousePointer.Idle,
             is MousePointer.Down,
@@ -222,7 +223,7 @@ class MainStateManager(
             is MousePointer.DoubleClick -> null
         }
         if (mouseCursor != null) {
-            canvasManager.setMouseCursor(mouseCursor)
+            canvasManager.setMouseCursor(mouseCursor.value)
         }
     }
 

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -223,7 +223,7 @@ class MainStateManager(
             is MousePointer.DoubleClick -> null
         }
         if (mouseCursor != null) {
-            canvasManager.setMouseCursor(mouseCursor.value)
+            canvasManager.setMouseCursor(mouseCursor)
         }
     }
 

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -207,10 +207,7 @@ class MainStateManager(
 
     private fun updateMouseCursor(mousePointer: MousePointer) {
         val mouseCursor = when (mousePointer) {
-            is MousePointer.Move -> {
-                val interactionPoint = canvasManager.getInteractionPoint(mousePointer.pointPx)
-                interactionPoint?.mouseCursor ?: MouseCursor.DEFAULT
-            }
+            is MousePointer.Move -> getMouseMovingCursor(mousePointer)
             is MousePointer.Drag -> {
                 val mouseCommand = currentMouseCommand
                 if (mouseCommand != null) mouseCommand.mouseCursor else MouseCursor.DEFAULT
@@ -224,6 +221,15 @@ class MainStateManager(
         }
         if (mouseCursor != null) {
             canvasManager.setMouseCursor(mouseCursor)
+        }
+    }
+
+    private fun getMouseMovingCursor(mousePointer: MousePointer.Move): MouseCursor {
+        val interactionPoint = canvasManager.getInteractionPoint(mousePointer.pointPx)
+        return when {
+            interactionPoint != null -> interactionPoint.mouseCursor
+            currentRetainableActionType != RetainableActionType.IDLE -> MouseCursor.CROSSHAIR
+            else -> MouseCursor.DEFAULT
         }
     }
 

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.DirectedPoint
 import mono.graphics.geo.MousePointer
@@ -10,7 +11,7 @@ import mono.state.command.CommandEnvironment
 import kotlin.math.abs
 
 internal class AddLineMouseCommand : MouseCommand {
-    override val mouseCursor: String = "crosshair"
+    override val mouseCursor: MouseCursor = MouseCursor.CROSSHAIR
 
     private var workingShape: Line? = null
 

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Point
@@ -13,7 +14,7 @@ import mono.state.command.CommandEnvironment
  * A [MouseCommand] to add new shape.
  */
 internal class AddShapeMouseCommand(private val shapeFactory: ShapeFactory) : MouseCommand {
-    override val mouseCursor: String = "crosshair"
+    override val mouseCursor: MouseCursor = MouseCursor.CROSSHAIR
 
     private var workingShape: AbstractShape? = null
 

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddTextMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddTextMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Point
@@ -21,7 +22,7 @@ import mono.state.command.text.EditTextShapeHelper
  * 2. Open a modal for entering text content when mouse up.
  */
 internal class AddTextMouseCommand(private val isTextEditable: Boolean) : MouseCommand {
-    override val mouseCursor: String = "crosshair"
+    override val mouseCursor: MouseCursor = MouseCursor.CROSSHAIR
 
     private var workingShape: Text? = null
     override fun execute(

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.DirectedPoint
 import mono.graphics.geo.MousePointer
@@ -17,7 +18,7 @@ internal class LineInteractionMouseCommand(
     private val lineShape: Line,
     private val interactionPoint: LineInteractionPoint
 ) : MouseCommand {
-    override val mouseCursor: String? = null
+    override val mouseCursor: MouseCursor? = null
 
     override fun execute(
         environment: CommandEnvironment,

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.graphics.geo.MousePointer
 import mono.state.MainStateManager
 import mono.state.command.CommandEnvironment
@@ -11,7 +12,7 @@ internal sealed interface MouseCommand {
     /**
      * CSS mouse cursor value to show during command execution.
      */
-    val mouseCursor: String?
+    val mouseCursor: MouseCursor?
 
     /**
      * Handles mouse events.

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Point
 import mono.shape.command.ChangeBound
@@ -11,7 +12,7 @@ import mono.state.command.mouse.MouseCommand.CommandResultType
  * A [MouseCommand] for moving selected shapes.
  */
 internal class MoveShapeMouseCommand(private val shapes: Set<AbstractShape>) : MouseCommand {
-    override val mouseCursor: String = "move"
+    override val mouseCursor: MouseCursor = MouseCursor.MOVE
 
     private val initialPositions = shapes.associate { it.id to it.bound.position }
 

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/ScaleShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/ScaleShapeMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Point
@@ -15,7 +16,7 @@ internal class ScaleShapeMouseCommand(
     private val shape: AbstractShape,
     private val interactionPoint: ScaleInteractionPoint
 ) : MouseCommand {
-    override val mouseCursor: String? = null
+    override val mouseCursor: MouseCursor? = null
 
     private val initialBound = shape.bound
     override fun execute(

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/SelectShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/SelectShapeMouseCommand.kt
@@ -1,5 +1,6 @@
 package mono.state.command.mouse
 
+import mono.common.MouseCursor
 import mono.graphics.geo.MousePointer
 import mono.graphics.geo.Rect
 import mono.state.command.CommandEnvironment
@@ -8,7 +9,7 @@ import mono.state.command.CommandEnvironment
  * A [MouseCommand] to select shapes.
  */
 internal object SelectShapeMouseCommand : MouseCommand {
-    override val mouseCursor: String = "default"
+    override val mouseCursor: MouseCursor = MouseCursor.DEFAULT
 
     override fun execute(
         environment: CommandEnvironment,


### PR DESCRIPTION
This PR does not update the cursor for each tool as it requires a custom image for the cursor. 
Drawing or setting an element moved along with a mouse is so lag.
Set custom mouse image is too hard to make right for each OS and browser and device