### PR TITLE
Fix background when edit text on filled box

### DIFF
--- a/libs/htmlmodal/src/main/kotlin/mono/html/modal/EditTextModal.kt
+++ b/libs/htmlmodal/src/main/kotlin/mono/html/modal/EditTextModal.kt
@@ -8,10 +8,10 @@ import mono.common.post
 import mono.html.Div
 import mono.html.Span
 import mono.html.px
-import mono.html.styleOf
 import mono.html.setAttributes
 import mono.html.setOnFocusOut
 import mono.html.setOnMouseWheelListener
+import mono.html.styleOf
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.events.KeyboardEvent
@@ -67,11 +67,11 @@ class EditTextModal(
         // This helps the editing text on filled box is readable.
         val backgroundAreaContainer = Div("modal-edit-text-area")
         val textBackgroundArea = Span(backgroundAreaContainer)
-        
+
         val textArea = Div("modal-edit-text-area") {
             setAttributes("contenteditable" to true)
         }
-        
+
         // This div is for HTML decoding
         val converterDiv = Div {
             setAttributes("style" to styleOf("display" to "none"))

--- a/libs/htmlmodal/src/main/kotlin/mono/html/modal/EditTextModal.kt
+++ b/libs/htmlmodal/src/main/kotlin/mono/html/modal/EditTextModal.kt
@@ -6,6 +6,7 @@ import mono.common.commandKey
 import mono.common.onKeyDown
 import mono.common.post
 import mono.html.Div
+import mono.html.Span
 import mono.html.px
 import mono.html.styleOf
 import mono.html.setAttributes
@@ -62,9 +63,15 @@ class EditTextModal(
     }
 
     private fun Element.initTextArea() {
+        // This div and span is for setting the white background under text.
+        // This helps the editing text on filled box is readable.
+        val backgroundAreaContainer = Div("modal-edit-text-area")
+        val textBackgroundArea = Span(backgroundAreaContainer)
+        
         val textArea = Div("modal-edit-text-area") {
             setAttributes("contenteditable" to true)
         }
+        
         // This div is for HTML decoding
         val converterDiv = Div {
             setAttributes("style" to styleOf("display" to "none"))
@@ -77,6 +84,7 @@ class EditTextModal(
                 converterDiv.innerHTML = it
                 converterDiv.innerText
             }
+            textBackgroundArea.innerText = text
             onTextChange(text)
         }
 

--- a/src/main/sass/style/edittext-modal.sass
+++ b/src/main/sass/style/edittext-modal.sass
@@ -34,3 +34,6 @@
             &:focus
                 outline: none
 
+            span
+                word-break: break-word
+                background: white


### PR DESCRIPTION
Set background when editing text
<img width="282" alt="image" src="https://user-images.githubusercontent.com/955306/218340739-a1b3a813-3a08-4dbd-a7d0-9832e1159efd.png">
