### PR TITLE
Adjust drawing info with Jetbrains Mono font

### DIFF
--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/BaseCanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/BaseCanvasViewController.kt
@@ -65,7 +65,11 @@ internal abstract class BaseCanvasViewController(private val canvas: HTMLCanvasE
     protected fun drawText(text: String, row: Int, column: Int) {
         val yPx = drawingInfo.toYPx(row.toDouble())
         val xPx = drawingInfo.toXPx(column.toDouble())
-        context.fillText(text, xPx, yPx)
+        context.fillText(
+            text,
+            xPx + drawingInfo.cellCharOffsetPx.width,
+            yPx + drawingInfo.cellCharOffsetPx.height
+        )
     }
 
     protected fun Path2D.addHLine(xPx: Double, yPx: Double, widthPx: Double) {

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
@@ -38,9 +38,12 @@ internal class DrawingInfoController(container: HTMLDivElement) {
     }
 
     fun setFont(fontSize: Int) {
+        val cellSizePx = context.getCellSizePx(fontSize)
+        val cellCharOffsetPx = SizeF(0.0, cellSizePx.height * 0.2)
         drawingInfoMutableLiveData.value =
             drawingInfoMutableLiveData.value.copy(
-                cellSizePx = context.getCellSizePx(fontSize),
+                cellSizePx = cellSizePx,
+                cellCharOffsetPx = cellCharOffsetPx,
                 font = "normal normal normal ${fontSize.px} $DEFAULT_FONT",
                 fontSize = fontSize
             )
@@ -59,14 +62,15 @@ internal class DrawingInfoController(container: HTMLDivElement) {
         context.font = font
         context.textAlign = CanvasTextAlign.LEFT
         context.textBaseline = CanvasTextBaseline.MIDDLE
-        val cWidth = floor(fontSize.toDouble() / 1.6)
-        val cHeight = fontSize.toDouble()
+        val cWidth = floor(fontSize.toDouble() * 0.63)
+        val cHeight = fontSize.toDouble() * 1.312
         return SizeF(cWidth, cHeight)
     }
 
     internal data class DrawingInfo(
         val offsetPx: Point = Point.ZERO,
         val cellSizePx: SizeF = SizeF(1.0, 1.0),
+        val cellCharOffsetPx: SizeF = SizeF(0.0, 0.0),
         val canvasSizePx: Size = Size(1, 1),
         val font: String = "",
         val fontSize: Int = 0


### PR DESCRIPTION
Before
<img width="694" alt="image" src="https://user-images.githubusercontent.com/955306/228084411-c590336e-6325-4f7e-923a-1736c03a8046.png">

After
<img width="685" alt="image" src="https://user-images.githubusercontent.com/955306/228084297-bd0fa552-e7e8-4174-bb92-be0b82cdabb1.png">
