### PR TITLE
Fix resizing

### DIFF
--- a/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/MousePointer.kt
+++ b/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/MousePointer.kt
@@ -11,31 +11,31 @@ sealed interface MousePointer {
     object Idle : MousePointer
 
     data class Move(
-        val point: Point,
+        val boardCoordinate: Point,
         val pointPx: Point
     ) : MousePointer
 
     data class Down(
-        val point: Point,
+        val boardCoordinate: Point,
         val pointPx: Point,
         val isWithShiftKey: Boolean
     ) : MousePointer
 
     data class Drag(
         val mouseDownPoint: Point,
-        val point: Point,
+        val boardCoordinate: Point,
         val boardCoordinateF: PointF,
         val isWithShiftKey: Boolean
     ) : MousePointer
 
     data class Up(
         val mouseDownPoint: Point,
-        val point: Point,
+        val boardCoordinate: Point,
         val boardCoordinateF: PointF,
         val isWithShiftKey: Boolean
     ) : MousePointer
 
-    data class Click(val point: Point, val isWithShiftKey: Boolean) : MousePointer
+    data class Click(val boardCoordinate: Point, val isWithShiftKey: Boolean) : MousePointer
 
-    data class DoubleClick(val point: Point) : MousePointer
+    data class DoubleClick(val boardCoordinate: Point) : MousePointer
 }

--- a/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/MousePointer.kt
+++ b/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/MousePointer.kt
@@ -24,12 +24,14 @@ sealed interface MousePointer {
     data class Drag(
         val mouseDownPoint: Point,
         val point: Point,
+        val boardCoordinateF: PointF,
         val isWithShiftKey: Boolean
     ) : MousePointer
 
     data class Up(
         val mouseDownPoint: Point,
         val point: Point,
+        val boardCoordinateF: PointF,
         val isWithShiftKey: Boolean
     ) : MousePointer
 

--- a/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/PointF.kt
+++ b/libs/graphicsgeo/src/main/kotlin/mono/graphics.geo/PointF.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023, tuanchauict
+ */
+
+package mono.graphics.geo
+
+/**
+ * A data class that represents a point in 2D space whose values are in float number.
+ * This class is only used for calculation, should not use for serialization or storage.
+ */
+data class PointF(val left: Double, val top: Double) {
+    val row: Double get() = top
+    val column: Double get() = left
+}

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -140,7 +140,8 @@ class MainStateManager(
     private fun onMouseEvent(mousePointer: MousePointer) {
         if (mousePointer is MousePointer.DoubleClick) {
             val targetedShape =
-                environment.getSelectedShapes().firstOrNull { it.contains(mousePointer.point) }
+                environment.getSelectedShapes()
+                    .firstOrNull { it.contains(mousePointer.boardCoordinate) }
             actionManager.setOneTimeAction(OneTimeActionType.EditSelectedShape(targetedShape))
             return
         }

--- a/libs/statemanager/src/main/kotlin/mono/state/command/MouseCommandFactory.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/MouseCommandFactory.kt
@@ -32,8 +32,10 @@ internal object MouseCommandFactory {
             mousePointer,
             commandType
         )
+
         is MousePointer.Click ->
             if (commandType == RetainableActionType.IDLE) SelectShapeMouseCommand else null
+
         is MousePointer.DoubleClick -> null
         is MousePointer.Move,
         is MousePointer.Drag,
@@ -77,7 +79,7 @@ internal object MouseCommandFactory {
         }
 
         if (!mousePointer.isWithShiftKey &&
-            commandEnvironment.isPointInInteractionBounds(mousePointer.point)
+            commandEnvironment.isPointInInteractionBounds(mousePointer.boardCoordinate)
         ) {
             return MoveShapeMouseCommand(selectedShapes)
         }
@@ -97,6 +99,7 @@ internal object MouseCommandFactory {
             is ScaleInteractionPoint -> ScaleShapeMouseCommand(shape, interactionPoint)
             is LineInteractionPoint ->
                 if (shape is Line) LineInteractionMouseCommand(shape, interactionPoint) else null
+
             null -> null
         }
     }

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
@@ -25,12 +25,12 @@ internal class AddLineMouseCommand : MouseCommand {
     ): MouseCommand.CommandResultType =
         when (mousePointer) {
             is MousePointer.Down -> {
-                val edgeDirection = environment.getEdgeDirection(mousePointer.point)
+                val edgeDirection = environment.getEdgeDirection(mousePointer.boardCoordinate)
                 val direction =
                     edgeDirection?.normalizedDirection ?: DirectedPoint.Direction.HORIZONTAL
                 val shape = Line(
-                    DirectedPoint(direction, mousePointer.point),
-                    DirectedPoint(DirectedPoint.Direction.VERTICAL, mousePointer.point),
+                    DirectedPoint(direction, mousePointer.boardCoordinate),
+                    DirectedPoint(DirectedPoint.Direction.VERTICAL, mousePointer.boardCoordinate),
                     parentId = environment.workingParentGroup.id
                 )
                 workingShape = shape
@@ -38,19 +38,21 @@ internal class AddLineMouseCommand : MouseCommand {
                 environment.clearSelectedShapes()
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Drag -> {
                 environment.changeEndAnchor(
                     environment,
-                    mousePointer.point,
+                    mousePointer.boardCoordinate,
                     mousePointer.isWithShiftKey,
                     isReducedRequired = false
                 )
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Up -> {
                 environment.changeEndAnchor(
                     environment,
-                    mousePointer.point,
+                    mousePointer.boardCoordinate,
                     mousePointer.isWithShiftKey,
                     isReducedRequired = true
                 )

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
@@ -29,18 +29,29 @@ internal class AddShapeMouseCommand(private val shapeFactory: ShapeFactory) : Mo
         when (mousePointer) {
             is MousePointer.Down -> {
                 val shape =
-                    shapeFactory.createShape(mousePointer.point, environment.workingParentGroup.id)
+                    shapeFactory.createShape(
+                        mousePointer.boardCoordinate,
+                        environment.workingParentGroup.id
+                    )
                 workingShape = shape
                 environment.addShape(shape)
                 environment.clearSelectedShapes()
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Drag -> {
-                environment.changeShapeBound(mousePointer.mouseDownPoint, mousePointer.point)
+                environment.changeShapeBound(
+                    mousePointer.mouseDownPoint,
+                    mousePointer.boardCoordinate
+                )
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Up -> {
-                environment.changeShapeBound(mousePointer.mouseDownPoint, mousePointer.point)
+                environment.changeShapeBound(
+                    mousePointer.mouseDownPoint,
+                    mousePointer.boardCoordinate
+                )
                 environment.addSelectedShape(workingShape)
                 workingShape = null
                 MouseCommand.CommandResultType.DONE

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddTextMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddTextMouseCommand.kt
@@ -36,8 +36,8 @@ internal class AddTextMouseCommand(private val isTextEditable: Boolean) : MouseC
         when (mousePointer) {
             is MousePointer.Down -> {
                 val shape = Text(
-                    mousePointer.point,
-                    mousePointer.point,
+                    mousePointer.boardCoordinate,
+                    mousePointer.boardCoordinate,
                     parentId = environment.workingParentGroup.id,
                     isTextEditable = isTextEditable
                 )
@@ -46,10 +46,15 @@ internal class AddTextMouseCommand(private val isTextEditable: Boolean) : MouseC
                 environment.clearSelectedShapes()
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Drag -> {
-                environment.changeShapeBound(mousePointer.mouseDownPoint, mousePointer.point)
+                environment.changeShapeBound(
+                    mousePointer.mouseDownPoint,
+                    mousePointer.boardCoordinate
+                )
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Up -> {
                 onMouseUp(environment, mousePointer)
                 MouseCommand.CommandResultType.WORKING_PHASE2
@@ -63,7 +68,7 @@ internal class AddTextMouseCommand(private val isTextEditable: Boolean) : MouseC
 
     private fun onMouseUp(environment: CommandEnvironment, mousePointer: MousePointer.Up) {
         val text = workingShape ?: return
-        environment.changeShapeBound(mousePointer.mouseDownPoint, mousePointer.point)
+        environment.changeShapeBound(mousePointer.mouseDownPoint, mousePointer.boardCoordinate)
 
         val isFreeText = text.isFreeText()
         if (isFreeText) {

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
@@ -29,8 +29,8 @@ internal class LineInteractionMouseCommand(
         mousePointer: MousePointer
     ): MouseCommand.CommandResultType {
         when (mousePointer) {
-            is MousePointer.Drag -> move(environment, mousePointer.point, false)
-            is MousePointer.Up -> move(environment, mousePointer.point, true)
+            is MousePointer.Drag -> move(environment, mousePointer.boardCoordinate, false)
+            is MousePointer.Up -> move(environment, mousePointer.boardCoordinate, true)
             is MousePointer.Down,
             is MousePointer.Click,
             is MousePointer.DoubleClick,
@@ -49,6 +49,7 @@ internal class LineInteractionMouseCommand(
         when (interactionPoint) {
             is LineInteractionPoint.Anchor ->
                 moveAnchor(environment, interactionPoint, point, isReducedRequired)
+
             is LineInteractionPoint.Edge ->
                 moveEdge(environment, interactionPoint, point, isReducedRequired)
         }

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
@@ -25,8 +25,8 @@ internal class MoveShapeMouseCommand(private val shapes: Set<AbstractShape>) : M
         mousePointer: MousePointer
     ): CommandResultType {
         val offset = when (mousePointer) {
-            is MousePointer.Drag -> mousePointer.point - mousePointer.mouseDownPoint
-            is MousePointer.Up -> mousePointer.point - mousePointer.mouseDownPoint
+            is MousePointer.Drag -> mousePointer.boardCoordinate - mousePointer.mouseDownPoint
+            is MousePointer.Up -> mousePointer.boardCoordinate - mousePointer.mouseDownPoint
             is MousePointer.Down,
             is MousePointer.Click,
             is MousePointer.DoubleClick,

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/ScaleShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/ScaleShapeMouseCommand.kt
@@ -7,7 +7,7 @@ package mono.state.command.mouse
 import mono.common.MouseCursor
 import mono.common.exhaustive
 import mono.graphics.geo.MousePointer
-import mono.graphics.geo.Point
+import mono.graphics.geo.PointF
 import mono.shape.command.ChangeBound
 import mono.shape.shape.AbstractShape
 import mono.shapebound.ScaleInteractionPoint
@@ -28,8 +28,8 @@ internal class ScaleShapeMouseCommand(
         mousePointer: MousePointer
     ): MouseCommand.CommandResultType {
         when (mousePointer) {
-            is MousePointer.Drag -> scale(environment, mousePointer.point)
-            is MousePointer.Up -> scale(environment, mousePointer.point)
+            is MousePointer.Drag -> scale(environment, mousePointer.boardCoordinateF)
+            is MousePointer.Up -> scale(environment, mousePointer.boardCoordinateF)
             is MousePointer.Down,
             is MousePointer.Click,
             is MousePointer.DoubleClick,
@@ -44,8 +44,9 @@ internal class ScaleShapeMouseCommand(
         }
     }
 
-    private fun scale(environment: CommandEnvironment, point: Point) {
-        val newBound = interactionPoint.createNewShapeBound(initialBound, point)
+    private fun scale(environment: CommandEnvironment, pointF: PointF) {
+        val newBound =
+            interactionPoint.createNewShapeBound(initialBound, pointF)
         environment.shapeManager.execute(ChangeBound(shape, newBound))
 
         environment.updateInteractionBounds()

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/SelectShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/SelectShapeMouseCommand.kt
@@ -26,20 +26,21 @@ internal object SelectShapeMouseCommand : MouseCommand {
                     Rect.byLTRB(
                         mousePointer.mouseDownPoint.left,
                         mousePointer.mouseDownPoint.top,
-                        mousePointer.point.left,
-                        mousePointer.point.top
+                        mousePointer.boardCoordinate.left,
+                        mousePointer.boardCoordinate.top
                     )
                 )
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Up -> {
                 environment.setSelectionBound(null)
 
                 val area = Rect.byLTRB(
                     mousePointer.mouseDownPoint.left,
                     mousePointer.mouseDownPoint.top,
-                    mousePointer.point.left,
-                    mousePointer.point.top
+                    mousePointer.boardCoordinate.left,
+                    mousePointer.boardCoordinate.top
                 )
 
                 val shapes = if (area.width * area.height > 1) {
@@ -56,8 +57,9 @@ internal object SelectShapeMouseCommand : MouseCommand {
                 }
                 MouseCommand.CommandResultType.WORKING
             }
+
             is MousePointer.Click -> {
-                val shapes = environment.shapeSearcher.getShapes(mousePointer.point)
+                val shapes = environment.shapeSearcher.getShapes(mousePointer.boardCoordinate)
                 if (shapes.isNotEmpty()) {
                     val shape = shapes.last()
                     if (mousePointer.isWithShiftKey) {
@@ -69,6 +71,7 @@ internal object SelectShapeMouseCommand : MouseCommand {
                 }
                 MouseCommand.CommandResultType.DONE
             }
+
             is MousePointer.DoubleClick,
             is MousePointer.Move,
             MousePointer.Idle -> MouseCommand.CommandResultType.DONE

--- a/libs/ui-canvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
+++ b/libs/ui-canvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
@@ -71,6 +71,10 @@ internal class DrawingInfoController(container: HTMLDivElement) {
         return SizeF(cWidth, cHeight)
     }
 
+    /**
+     * A data class to hold drawing info and provide conversion functions for converting between
+     * pixel unit and board unit.
+     */
     internal data class DrawingInfo(
         val offsetPx: Point = Point.ZERO,
         val cellSizePx: SizeF = SizeF(1.0, 1.0),
@@ -92,11 +96,46 @@ internal class DrawingInfoController(container: HTMLDivElement) {
         internal val boardColumnRange: IntRange =
             boardOffsetColumn..(boardOffsetColumn + columnCount)
 
+        /**
+         * Converts the board column to pixel X coordinate.
+         * Algorithm:
+         * 1. Multiply the board column by the cell width.
+         * 2. Add the left offset.
+         */
         fun toXPx(column: Double): Double = floor(offsetPx.left + cellSizePx.width * column)
+
+        /**
+         * Converts the board row to pixel Y coordinate.
+         * Algorithm:
+         * 1. Multiply the board row by the cell height.
+         * 2. Add the top offset.
+         */
         fun toYPx(row: Double): Double = floor(offsetPx.top + cellSizePx.height * row)
+
+        /**
+         * Converts the screen Y coordinate (pixel) to the board row.
+         * Algorithm:
+         * 1. Subtract the top offset from the Y coordinate.
+         * 2. Divide the result by the cell height.
+         */
         fun toBoardRow(yPx: Int): Int = floor((yPx - offsetPx.top) / cellSizePx.height).toInt()
+
+        /**
+         * Converts the screen X coordinate (pixel) to the board column.
+         * Algorithm:
+         * 1. Subtract the left offset from the X coordinate.
+         * 2. Divide the result by the cell width.
+         */
         fun toBoardColumn(xPx: Int): Int = floor((xPx - offsetPx.left) / cellSizePx.width).toInt()
+
+        /**
+         * Converts the width in the board unit to pixel unit.
+         */
         fun toWidthPx(width: Double) = floor(cellSizePx.width * width)
+
+        /**
+         * Converts the height in the board unit to pixel unit.
+         */
         fun toHeightPx(height: Double) = floor(cellSizePx.height * height)
     }
 

--- a/libs/ui-canvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
+++ b/libs/ui-canvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
@@ -21,6 +21,7 @@ import org.w3c.dom.LEFT
 import org.w3c.dom.MIDDLE
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.math.round
 
 /**
  * A controller class to manage drawing info for the other canvas.
@@ -129,6 +130,24 @@ internal class DrawingInfoController(container: HTMLDivElement) {
         fun toBoardColumn(xPx: Int): Int = floor((xPx - offsetPx.left) / cellSizePx.width).toInt()
 
         /**
+         * Converts the pixel Y coordinate (pixel) to the board row with 1 decimal place.
+         * Algorithm:
+         * 1. Subtract the top offset from the Y coordinate.
+         * 2. Divide the result by the cell height.
+         */
+        fun toBoardRowF(yPx: Int): Double =
+            roundTo1DecimalPlace((yPx - offsetPx.top) / cellSizePx.height)
+
+        /**
+         * Converts the screen X coordinate (pixel) to the board column with 1 decimal place.
+         * Algorithm:
+         * 1. Subtract the left offset from the X coordinate.
+         * 2. Divide the result by the cell width.
+         */
+        fun toBoardColumnF(xPx: Int): Double =
+            roundTo1DecimalPlace((xPx - offsetPx.left) / cellSizePx.width)
+
+        /**
          * Converts the width in the board unit to pixel unit.
          */
         fun toWidthPx(width: Double) = floor(cellSizePx.width * width)
@@ -137,6 +156,13 @@ internal class DrawingInfoController(container: HTMLDivElement) {
          * Converts the height in the board unit to pixel unit.
          */
         fun toHeightPx(height: Double) = floor(cellSizePx.height * height)
+
+        /**
+         * Rounds the value to 1 decimal place.
+         */
+        private fun roundTo1DecimalPlace(value: Double): Double {
+            return round(value * 10.0) / 10.0
+        }
     }
 
     companion object {

--- a/libs/ui-canvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
+++ b/libs/ui-canvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
@@ -186,6 +186,10 @@ internal class MouseEventObserver(
 
     private fun MouseEvent.toPointPx(): Point = Point(offsetX.toInt(), offsetY.toInt())
 
+    /**
+     * A class for detecting double click.
+     * If two mouse ups happen within 500ms, it's a double click.
+     */
     private class MouseDoubleClickDetector {
         private var lastMouseUpMillis: Long = 0
         private var mouseUpCount: Int = 0

--- a/libs/ui-canvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
+++ b/libs/ui-canvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
@@ -80,7 +80,7 @@ internal class MouseEventObserver(
         mousePointerMutableLiveData.value = when (currentValue) {
             is MousePointer.Down ->
                 MousePointer.Up(
-                    currentValue.point,
+                    currentValue.boardCoordinate,
                     event.toBoardCoordinate(),
                     event.toBoardCoordinateF(),
                     event.shiftKey
@@ -116,12 +116,12 @@ internal class MouseEventObserver(
         val newPointer = when (val mousePointer = mousePointerLiveData.value) {
             is MousePointer.Down ->
                 MousePointer.Drag(
-                    mousePointer.point,
+                    mousePointer.boardCoordinate,
                     event.toBoardCoordinate(),
                     event.toBoardCoordinateF(),
                     event.shiftKey
                 )
-                    .takeIf { it.point != mousePointer.point }
+                    .takeIf { it.boardCoordinate != mousePointer.boardCoordinate }
 
             is MousePointer.Drag ->
                 MousePointer.Drag(


### PR DESCRIPTION
Resize shape is annoying for the first change: it changes 2 units for the first move.
This is because, at first, the scale method relies on the mouse position which is on the interaction points, but then, the position is applied to the shape and the mouse is not on the edge of the shape instead of the interaction points as the beginning.

To fix this, we adjust the mouse point 80% of the unit (+80% for the left and top edges, -80% for the right and bottom edges)