### PR TITLE
Enable compose plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 plugins {
     kotlin("js") version "1.8.20"
     kotlin("plugin.serialization") version "1.8.20"
+    id("org.jetbrains.compose") version "1.4.0"
     id("io.miret.etienne.sass") version "1.4.0"
 }
 
@@ -34,26 +35,15 @@ val compilerType: KotlinJsCompilerType by ext
 kotlin {
     js(compilerType) {
         browser {
-            binaries.executable()
             testTask {
                 useKarma {
                     useChromeHeadless()
                 }
             }
         }
+        binaries.executable()
     }
 }
 
 apply(from = "ktlint.gradle")
 apply(from = "sass.gradle")
-
-// TODO: Move this into a separate script inside buildSrc
-// watchSass. This is not required when running the project.
-// Only run this task (along with run task) if you want to see the UI update immediately when
-// editing the style
-tasks.register<io.miret.etienne.gradle.sass.CompileSass>("watchSass") {
-    setSourceDir(project.file("$projectDir/src/main/sass"))
-    outputDir = project.file("$buildDir/processedResources/js/main")
-
-    watch()
-}

--- a/libs/ui-modal/build.gradle.kts
+++ b/libs/ui-modal/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     kotlin("js")
+    id("org.jetbrains.compose")
 }
 
 repositories {
@@ -16,6 +17,8 @@ dependencies {
     implementation(projects.lifecycle)
     implementation(projects.livedata)
 
+    implementation(compose.html.core)
+    implementation(compose.runtime)
     testImplementation(libs.kotlin.test.js)
 }
 


### PR DESCRIPTION
From here, we can use compose HTML in the project.
Because the compose runtime also depends on the Flow, maybe we will change the current `LiveData` to use `Flow` or just `State` from the compose, either should be fine.

The size of the compiled JS output will increase by ~250KB, including the Flow and State APIs.
By replacing the current LiveData, we can reduce the net increase a little bit (~1kb 😂)