### PR TITLE
Update the mono file format with more information

### DIFF
--- a/libs/shape-serialization/build.gradle.kts
+++ b/libs/shape-serialization/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     kotlin("js")
+    kotlin("plugin.serialization")
 }
 
 repositories {

--- a/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/MonoFile.kt
+++ b/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/MonoFile.kt
@@ -7,6 +7,7 @@ package mono.shape.serialization
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import mono.common.currentTimeMillis
+import mono.graphics.geo.Point
 
 const val MONO_FILE_VERSION = 1
 
@@ -36,5 +37,7 @@ data class MonoFile internal constructor(
 @Serializable
 data class Extra(
     @SerialName("name")
-    val name: String
+    val name: String,
+    @SerialName("offset")
+    val offset: Point = Point.ZERO
 )

--- a/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/MonoFile.kt
+++ b/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/MonoFile.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, tuanchauict
+ */
+
+package mono.shape.serialization
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import mono.common.currentTimeMillis
+
+const val MONO_FILE_VERSION = 1
+
+/**
+ * A data class for serializing shape to Json and load shape from Json.
+ *
+ */
+@Serializable
+data class MonoFile internal constructor(
+    @SerialName("root")
+    val root: SerializableGroup,
+    @SerialName("extra")
+    val extra: Extra,
+    @SerialName("version")
+    val version: Int,
+    @SerialName("modified_timestamp_millis")
+    val modifiedTimestampMillis: Long
+) {
+    constructor(root: SerializableGroup, extra: Extra) : this(
+        root,
+        extra,
+        MONO_FILE_VERSION,
+        currentTimeMillis().toLong()
+    )
+}
+
+@Serializable
+data class Extra(
+    @SerialName("name")
+    val name: String
+)

--- a/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/ShapeSerializationUtil.kt
+++ b/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/ShapeSerializationUtil.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mono.graphics.geo.Point
 
 /**
  * A util object for serializing shape to Json and load shape from Json
@@ -24,8 +25,9 @@ object ShapeSerializationUtil {
         null
     }
 
-    fun toMonoFileJson(name: String, serializableShape: SerializableGroup): String {
-        val monoFile = MonoFile(serializableShape, Extra(name))
+    fun toMonoFileJson(name: String, serializableShape: SerializableGroup, offset: Point): String {
+        val extra = Extra(name, offset)
+        val monoFile = MonoFile(serializableShape, extra)
         return Json.encodeToString(monoFile)
     }
 
@@ -34,7 +36,7 @@ object ShapeSerializationUtil {
     } catch (e: SerializationException) {
         // Fallback to version 0
         val shape = Json.decodeFromString<SerializableGroup>(jsonString)
-        MonoFile(shape, Extra(""))
+        MonoFile(shape, Extra("", Point.ZERO))
     } catch (e: Exception) {
         console.error("Error while restoring shapes")
         console.error(e)

--- a/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/ShapeSerializationUtil.kt
+++ b/libs/shape-serialization/src/main/kotlin/mono/shape/serialization/ShapeSerializationUtil.kt
@@ -4,12 +4,13 @@
 
 package mono.shape.serialization
 
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /**
- * An util object for serializing shape to Json and load shape from Json
+ * A util object for serializing shape to Json and load shape from Json
  */
 object ShapeSerializationUtil {
     fun toJson(serializableShape: AbstractSerializableShape): String =
@@ -17,6 +18,23 @@ object ShapeSerializationUtil {
 
     fun fromJson(jsonString: String): AbstractSerializableShape? = try {
         Json.decodeFromString(jsonString)
+    } catch (e: Exception) {
+        console.error("Error while restoring shapes")
+        console.error(e)
+        null
+    }
+
+    fun toMonoFileJson(name: String, serializableShape: SerializableGroup): String {
+        val monoFile = MonoFile(serializableShape, Extra(name))
+        return Json.encodeToString(monoFile)
+    }
+
+    fun fromMonoFileJson(jsonString: String): MonoFile? = try {
+        Json.decodeFromString<MonoFile>(jsonString)
+    } catch (e: SerializationException) {
+        // Fallback to version 0
+        val shape = Json.decodeFromString<SerializableGroup>(jsonString)
+        MonoFile(shape, Extra(""))
     } catch (e: Exception) {
         console.error("Error while restoring shapes")
         console.error(e)

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
@@ -48,7 +48,7 @@ open class Group(
         versionCode = serializableGroup.versionCode
     }
 
-    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape =
+    override fun toSerializableShape(isIdIncluded: Boolean): SerializableGroup =
         SerializableGroup(
             id.takeIf { isIdIncluded },
             versionCode,

--- a/libs/statemanager/src/main/kotlin/mono/state/FileMediator.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/FileMediator.kt
@@ -19,12 +19,12 @@ import org.w3c.files.get
  * A mediator class for file interactions.
  */
 internal class FileMediator {
-    fun saveFile(jsonString: String) {
+    fun saveFile(filename: String, jsonString: String) {
         document.body?.run {
             val fileBlob = Blob(arrayOf(jsonString))
             val node = A(classes = "hidden") {
                 href = URL.Companion.createObjectURL(fileBlob)
-                setAttributes("download" to "$DEFAULT_FILENAME.$EXTENSION")
+                setAttributes("download" to "$filename.$EXTENSION")
             }
             node.click()
             node.remove()
@@ -55,7 +55,6 @@ internal class FileMediator {
     }
 
     companion object {
-        private const val DEFAULT_FILENAME = "monosketch"
         private const val EXTENSION = "mono"
     }
 }

--- a/libs/statemanager/src/main/kotlin/mono/state/onetimeaction/FileRelatedActionsHelper.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/onetimeaction/FileRelatedActionsHelper.kt
@@ -65,8 +65,10 @@ internal class FileRelatedActionsHelper(
     fun saveCurrentShapesToFile() {
         val currentRoot = environment.shapeManager.root
         val serializableRoot = currentRoot.toSerializableShape(true)
-        val name = workspaceDao.getObject(currentRoot.id).name
-        val jsonString = ShapeSerializationUtil.toMonoFileJson(name, serializableRoot)
+        val objectDao = workspaceDao.getObject(currentRoot.id)
+        val name = objectDao.name
+        val offset = objectDao.offset
+        val jsonString = ShapeSerializationUtil.toMonoFileJson(name, serializableRoot, offset)
         fileMediator.saveFile(name, jsonString)
     }
 
@@ -81,7 +83,15 @@ internal class FileRelatedActionsHelper(
             // TODO: Check if the same root id is already in the workspace dao
             console.log(monoFile)
             val rootGroup = RootGroup(monoFile.root)
-            workspaceDao.getObject(rootGroup.id).name = monoFile.extra.name
+            // Prepare the object to be replaced since the data on the UI rely on the current root
+            // id to know an update.
+            // - Set name to the storage
+            // - Set offset to the storage
+            workspaceDao.getObject(rootGroup.id).run {
+                name = monoFile.extra.name
+                offset = monoFile.extra.offset
+            }
+
             replaceWorkspace(rootGroup)
         }
     }

--- a/libs/store-dao/src/main/kotlin/mono/store/dao/workspace/WorkspaceObjectDao.kt
+++ b/libs/store-dao/src/main/kotlin/mono/store/dao/workspace/WorkspaceObjectDao.kt
@@ -50,7 +50,7 @@ class WorkspaceObjectDao internal constructor(
         }
 
     var name: String
-        get() = objectDocument.get(OBJECT_NAME) ?: "Undefined"
+        get() = objectDocument.get(OBJECT_NAME) ?: DEFAULT_NAME
         set(value) {
             objectDocument.set(OBJECT_NAME, value)
             lastModifiedTimestampMillis = currentTimeMillis()
@@ -81,5 +81,9 @@ class WorkspaceObjectDao internal constructor(
             remove(OBJECT_NAME)
             remove(OBJECT_LAST_MODIFIED)
         }
+    }
+
+    companion object {
+        const val DEFAULT_NAME = "Undefined"
     }
 }


### PR DESCRIPTION
Instead of storing the root group as the main content of the JSON file, create a new class for the mono file. Sample:

```json
{
    "root": {
        "i": "01-AAtCb+0HOere+Tl28pvlYowBuZY",
        "v": 1586431400,
        "ss": [
            {
                "type": "T",
                "i": "01-AAsmqv4f4f7AEmAOR3tej8UNgMC",
                "v": -656325960,
                "b": "17|13|16|3",
                "t": "Hello World!",
                "e": {
                    "be": {
                        "fe": true,
                        "fu": "F1",
                        "be": true,
                        "bu": "S1",
                        "du": "1|0|0"
                    },
                    "tha": 1,
                    "tva": 1
                }
            }
        ]
    },
    "extra": {
        "name": "this is file",
        "offset": "104|71"
    },
    "version": 1,
    "modified_timestamp_millis": 1684026059297
}
```