### PR TITLE
No new joint point when moving anchor

### DIFF
--- a/libs/shape/src/main/kotlin/mono/shape/command/LineCommands.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/command/LineCommands.kt
@@ -23,6 +23,7 @@ class MoveLineAnchor(
     private val target: Line,
     private val anchorPointUpdate: Line.AnchorPointUpdate,
     private val isUpdateConfirmed: Boolean,
+    private val justMoveAnchor: Boolean,
     private val connectableCandidateShapes: List<AbstractShape>
 ) : Command() {
     override fun getDirectAffectedParent(shapeManager: ShapeManager): Group? =
@@ -30,7 +31,11 @@ class MoveLineAnchor(
 
     override fun execute(shapeManager: ShapeManager, parent: Group) {
         val currentVersion = target.versionCode
-        target.moveAnchorPoint(anchorPointUpdate, isUpdateConfirmed)
+        target.moveAnchorPoint(
+            anchorPointUpdate,
+            isReduceRequired = isUpdateConfirmed,
+            justMoveAnchor = justMoveAnchor
+        )
         if (currentVersion == target.versionCode) {
             return
         }

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -182,45 +182,86 @@ class Line(
      *
      * Examples for moved:
      * Case 1. Line's edges are never moved: see examples in the class doc
-     * Case 2. Line's edges have been moved
+     *
+     * Case 2. Line's edges have been moved and [justMoveAnchor] is true and number of joint points
+     * is larger than 2: update the position of the anchor and the adjacent point:
+     * Input
+     * ```
+     * +-----+
+     *       |
+     *       o
+     * ```
+     * Output
+     * ```
+     * +------------+
+     *              |
+     *              |
+     *              o
+     * ```
+     *
+     * Case 3. Line's edges have been moved and [justMoveAnchor] is false:
      * Input
      * ```
      * +-------o
      * ```
      * Result:
-     * Same line
+     * 3.1. Same line: only update the anchor's position
      * ```
      * +---------------x
      * ```
      *
-     * 2.2. Different lines
+     * 3.2. Different lines: create new joint point
      * ```
      * +----------+
      *            |
      *            x
      * ```
-     *
      */
-    fun moveAnchorPoint(anchorPointUpdate: AnchorPointUpdate, isReduceRequired: Boolean) = update {
+    fun moveAnchorPoint(
+        anchorPointUpdate: AnchorPointUpdate,
+        isReduceRequired: Boolean,
+        justMoveAnchor: Boolean = true
+    ) = update {
         when (anchorPointUpdate.anchor) {
             Anchor.START -> startPoint = anchorPointUpdate.point
             Anchor.END -> endPoint = anchorPointUpdate.point
         }
 
         val isEdgeUpdated = confirmedJointPoints.isNotEmpty()
-        val newJointPoints = if (!isEdgeUpdated) {
-            val seedPoints = listOf(startPoint, endPoint)
-            LineHelper.createJointPoints(seedPoints)
-        } else {
-            val newJointPoint = confirmedJointPoints.createNewJointPoint(anchorPointUpdate)
-            confirmedJointPoints.toMutableList().apply {
-                val (anchorIndex, newJointPointIndex) = when (anchorPointUpdate.anchor) {
-                    Anchor.START -> 0 to 1
-                    Anchor.END -> lastIndex to lastIndex
+        val newJointPoints = when {
+            !isEdgeUpdated -> {
+                val seedPoints = listOf(startPoint, endPoint)
+                LineHelper.createJointPoints(seedPoints)
+            }
+
+            justMoveAnchor && confirmedJointPoints.size > 2 -> {
+                confirmedJointPoints.toMutableList().apply {
+                    val (anchorIndex, affectedIndex) = when (anchorPointUpdate.anchor) {
+                        Anchor.START -> 0 to 1
+                        Anchor.END -> lastIndex to lastIndex - 1
+                    }
+
+                    val newPoint = anchorPointUpdate.point.point
+                    this[affectedIndex] = if (this[anchorIndex].left == this[affectedIndex].left) {
+                        this[affectedIndex].copy(left = newPoint.left)
+                    } else {
+                        this[affectedIndex].copy(top = newPoint.top)
+                    }
+                    this[anchorIndex] = newPoint
                 }
-                this[anchorIndex] = anchorPointUpdate.point.point
-                if (newJointPoint != null) {
-                    add(newJointPointIndex, newJointPoint)
+            }
+
+            else -> {
+                val newJointPoint = confirmedJointPoints.createNewJointPoint(anchorPointUpdate)
+                confirmedJointPoints.toMutableList().apply {
+                    val (anchorIndex, newJointPointIndex) = when (anchorPointUpdate.anchor) {
+                        Anchor.START -> 0 to 1
+                        Anchor.END -> lastIndex to lastIndex
+                    }
+                    this[anchorIndex] = anchorPointUpdate.point.point
+                    if (newJointPoint != null) {
+                        add(newJointPointIndex, newJointPoint)
+                    }
                 }
             }
         }

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -220,7 +220,7 @@ class Line(
     fun moveAnchorPoint(
         anchorPointUpdate: AnchorPointUpdate,
         isReduceRequired: Boolean,
-        justMoveAnchor: Boolean = true
+        justMoveAnchor: Boolean
     ) = update {
         when (anchorPointUpdate.anchor) {
             Anchor.START -> startPoint = anchorPointUpdate.point

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -75,6 +75,8 @@ import mono.shape.shape.line.LineHelper
  *      |
  *      x
  * ```
+ *
+ * TODO: Extract move anchor point and move edge code to use case class
  */
 class Line(
     startPoint: DirectedPoint,

--- a/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
@@ -14,7 +14,7 @@ import mono.shape.serialization.SerializableLine
 import mono.shape.shape.line.LineHelper
 
 /**
- * A test for [Line]
+ * A test for [Line].
  */
 class LineTest {
     @Test
@@ -41,11 +41,13 @@ class LineTest {
         val newEndPoint = DirectedPoint(DirectedPoint.Direction.VERTICAL, 7, 8)
         line.moveAnchorPoint(
             Line.AnchorPointUpdate(Line.Anchor.START, newStartPoint),
-            isReduceRequired = true
+            isReduceRequired = true,
+            justMoveAnchor = false
         )
         line.moveAnchorPoint(
             Line.AnchorPointUpdate(Line.Anchor.END, newEndPoint),
-            isReduceRequired = true
+            isReduceRequired = true,
+            justMoveAnchor = false
         )
 
         val serializableLine = line.toSerializableShape(true) as SerializableLine
@@ -96,11 +98,13 @@ class LineTest {
         val newEndPoint = DirectedPoint(DirectedPoint.Direction.VERTICAL, 7, 8)
         line.moveAnchorPoint(
             Line.AnchorPointUpdate(Line.Anchor.START, newStartPoint),
-            isReduceRequired = true
+            isReduceRequired = true,
+            justMoveAnchor = false
         )
         line.moveAnchorPoint(
             Line.AnchorPointUpdate(Line.Anchor.END, newEndPoint),
-            isReduceRequired = true
+            isReduceRequired = true,
+            justMoveAnchor = false
         )
 
         val serializableLine = line.toSerializableShape(true) as SerializableLine

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddLineMouseCommand.kt
@@ -85,6 +85,7 @@ internal class AddLineMouseCommand : MouseCommand {
                 line,
                 anchorPointUpdate,
                 isReducedRequired,
+                justMoveAnchor = false,
                 connectableCandidateShapes = environment.shapeSearcher.getShapes(point)
             )
         )

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
@@ -29,8 +29,20 @@ internal class LineInteractionMouseCommand(
         mousePointer: MousePointer
     ): MouseCommand.CommandResultType {
         when (mousePointer) {
-            is MousePointer.Drag -> move(environment, mousePointer.boardCoordinate, false)
-            is MousePointer.Up -> move(environment, mousePointer.boardCoordinate, true)
+            is MousePointer.Drag -> move(
+                environment,
+                mousePointer.boardCoordinate,
+                isUpdateConfirmed = false,
+                justMoveAnchor = !mousePointer.isWithShiftKey
+            )
+
+            is MousePointer.Up -> move(
+                environment,
+                mousePointer.boardCoordinate,
+                isUpdateConfirmed = true,
+                justMoveAnchor = !mousePointer.isWithShiftKey
+            )
+
             is MousePointer.Down,
             is MousePointer.Click,
             is MousePointer.DoubleClick,
@@ -45,10 +57,15 @@ internal class LineInteractionMouseCommand(
         }
     }
 
-    private fun move(environment: CommandEnvironment, point: Point, isUpdateConfirmed: Boolean) {
+    private fun move(
+        environment: CommandEnvironment,
+        point: Point,
+        isUpdateConfirmed: Boolean,
+        justMoveAnchor: Boolean
+    ) {
         when (interactionPoint) {
             is LineInteractionPoint.Anchor ->
-                moveAnchor(environment, interactionPoint, point, isUpdateConfirmed)
+                moveAnchor(environment, interactionPoint, point, isUpdateConfirmed, justMoveAnchor)
 
             is LineInteractionPoint.Edge ->
                 moveEdge(environment, interactionPoint, point, isUpdateConfirmed)
@@ -59,7 +76,8 @@ internal class LineInteractionMouseCommand(
         environment: CommandEnvironment,
         interactionPoint: LineInteractionPoint.Anchor,
         point: Point,
-        isUpdateConfirmed: Boolean
+        isUpdateConfirmed: Boolean,
+        justMoveAnchor: Boolean
     ) {
         val edgeDirection = environment.getEdgeDirection(point)
         val direction =
@@ -73,8 +91,7 @@ internal class LineInteractionMouseCommand(
                 lineShape,
                 anchorPointUpdate,
                 isUpdateConfirmed,
-                // TODO: Allow setting this option with keyboard
-                justMoveAnchor = false,
+                justMoveAnchor = justMoveAnchor,
                 // TODO: If the performance is bad when moving the shape, it's okay to only search
                 //  for the candidates when the action is end (mouse up)
                 connectableCandidateShapes = environment.shapeSearcher.getShapes(point)

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/LineInteractionMouseCommand.kt
@@ -73,6 +73,8 @@ internal class LineInteractionMouseCommand(
                 lineShape,
                 anchorPointUpdate,
                 isUpdateConfirmed,
+                // TODO: Allow setting this option with keyboard
+                justMoveAnchor = false,
                 // TODO: If the performance is bad when moving the shape, it's okay to only search
                 //  for the candidates when the action is end (mouse up)
                 connectableCandidateShapes = environment.shapeSearcher.getShapes(point)

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/MoveShapeMouseCommand.kt
@@ -53,7 +53,11 @@ internal class MoveShapeMouseCommand(private val shapes: Set<AbstractShape>) : M
                     connector.getPointInNewBound(line.getDirection(connector.anchor), newBound)
                 )
 
-                line.moveAnchorPoint(anchorPointUpdate, isUpdateConfirmed)
+                line.moveAnchorPoint(
+                    anchorPointUpdate,
+                    isReduceRequired = isUpdateConfirmed,
+                    justMoveAnchor = true
+                )
             }
         }
 


### PR DESCRIPTION
By default, when moving a line after having an edge update won't add a new joint point if the number of vertices is more than 2. Otherwise, press shift key when moving the anchor to add new joint point

https://github.com/tuanchauict/MonoSketch/assets/955306/f6dfa07c-ee3a-45c2-b447-999f6ed478c4

