### PR TITLE
Fix hover while dragging and line select becomes line move

### DIFF
--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -355,8 +355,8 @@ class MainStateManager(
             focusType: ShapeFocusType
         ) = stateManager.selectedShapeManager.setFocusingShape(shape, focusType)
 
-        override fun getFocusingShape(): AbstractShape? =
-            stateManager.selectedShapeManager.focusingShape?.shape
+        override fun getFocusingShape(): SelectedShapeManager.FocusingShape? =
+            stateManager.selectedShapeManager.focusingShape
 
         override fun selectAllShapes() {
             for (shape in stateManager.workingParentGroup.items) {

--- a/libs/statemanager/src/main/kotlin/mono/state/command/CommandEnvironment.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/CommandEnvironment.kt
@@ -66,7 +66,7 @@ internal interface CommandEnvironment {
 
     fun setFocusingShape(shape: AbstractShape?, focusType: SelectedShapeManager.ShapeFocusType)
 
-    fun getFocusingShape(): AbstractShape?
+    fun getFocusingShape(): SelectedShapeManager.FocusingShape?
 
     fun selectAllShapes()
 

--- a/libs/statemanager/src/main/kotlin/mono/state/command/MouseCommandFactory.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/MouseCommandFactory.kt
@@ -6,6 +6,7 @@ package mono.state.command
 
 import mono.actionmanager.RetainableActionType
 import mono.graphics.geo.MousePointer
+import mono.shape.selection.SelectedShapeManager.ShapeFocusType.SELECT_MODE_HOVER
 import mono.shape.shape.Line
 import mono.shapebound.InteractionPoint
 import mono.shapebound.LineInteractionPoint
@@ -65,16 +66,17 @@ internal object MouseCommandFactory {
         environment: CommandEnvironment,
         mousePointer: MousePointer.Down
     ): MouseCommand? {
-        val focusingShape = environment.getFocusingShape()
+        val focusingShape =
+            environment.getFocusingShape()?.takeIf { it.focusType == SELECT_MODE_HOVER }
 
         if (!mousePointer.isWithShiftKey &&
             focusingShape != null &&
-            focusingShape !in environment.getSelectedShapes()
+            focusingShape.shape !in environment.getSelectedShapes()
         ) {
             // If focusing shape is not selected and not in multiple selection mode (Shift key),
             // clear all selected shapes and select focusing shape.
             environment.clearSelectedShapes()
-            environment.addSelectedShape(focusingShape)
+            environment.addSelectedShape(focusingShape.shape)
         }
         val selectedShapes = environment.getSelectedShapes()
         if (selectedShapes.isEmpty()) {

--- a/libs/statemanager/src/main/kotlin/mono/state/utils/UpdateShapeBoundHelper.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/utils/UpdateShapeBoundHelper.kt
@@ -67,7 +67,11 @@ internal object UpdateShapeBoundHelper {
 
         for (lineId in lineIds) {
             val line = environment.shapeManager.getShape(lineId) as? Line ?: continue
-            dataProvider.updatePosition(line)
+            val oldBound = line.bound
+            val newBound = dataProvider.updatePosition(line)
+            if (newBound == null || newBound == oldBound) {
+                continue
+            }
 
             // Remove connectors of line if its connected shapes are not selected.
             if (lineId !in lineIdToHeadCountMap) {


### PR DESCRIPTION
- While drawing a line and connecting with the shape, it becomes a moving shape -> fix: connect line with shape instead
- Selecting line becomes moving line command, and this removes connectors -> fix: only actual move will remove the connectors

Side effect of #568