### PR TITLE
Prioritize the interaction point over unselected shape when identifying hover shape

### DIFF
--- a/libs/statemanager/src/main/kotlin/mono/state/controller/MouseInteractionController.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/controller/MouseInteractionController.kt
@@ -91,7 +91,7 @@ internal class MouseInteractionController(
             RetainableActionType.IDLE -> {
                 val hoverShape =
                     if (!environment.isOnInteractionPoint(mousePointer)) {
-                        // Only hover shape when the mouse is not on interaction points of the 
+                        // Only hover shape when the mouse is not on interaction points of the
                         // current selected shapes
                         hoverShapeManager.getHoverShape(environment, mousePointer.boardCoordinate)
                     } else {

--- a/libs/statemanager/src/main/kotlin/mono/state/controller/MouseInteractionController.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/controller/MouseInteractionController.kt
@@ -89,10 +89,15 @@ internal class MouseInteractionController(
             }
 
             RetainableActionType.IDLE -> {
-                val hoverShape = hoverShapeManager.getHoverShape(
-                    environment,
-                    mousePointer.boardCoordinate
-                )
+                val hoverShape =
+                    if (!environment.isOnInteractionPoint(mousePointer)) {
+                        // Only hover shape when the mouse is not on interaction points of the 
+                        // current selected shapes
+                        hoverShapeManager.getHoverShape(environment, mousePointer.boardCoordinate)
+                    } else {
+                        null
+                    }
+
                 hoverShape to SelectedShapeManager.ShapeFocusType.SELECT_MODE_HOVER
             }
 
@@ -103,5 +108,18 @@ internal class MouseInteractionController(
         } ?: return
         environment.setFocusingShape(hoverShape, type)
         requestRedraw()
+    }
+
+    private fun CommandEnvironment.isOnInteractionPoint(mousePointer: MousePointer): Boolean {
+        val pointPx = when (mousePointer) {
+            is MousePointer.Down -> mousePointer.pointPx
+            is MousePointer.Move -> mousePointer.pointPx
+            MousePointer.Idle,
+            is MousePointer.Drag,
+            is MousePointer.Up,
+            is MousePointer.Click,
+            is MousePointer.DoubleClick -> null
+        } ?: return false
+        return getInteractionPoint(pointPx) != null
     }
 }


### PR DESCRIPTION
The feature moving without selection creates a bad UX for the currently selected shapes: top shapes have higher priority than currently selected shapes -> interaction points are ignored.

In this PR, I change the priority of the mouse point to the interaction points instead of underlying shapes: only focus on the shape when the mouse is not on any interaction point.