### PR TITLE
Simplify crossing point algorithm and allow complex combination to joinable

### DIFF
--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -519,19 +519,35 @@ internal object CrossingResources {
         surroundingLeft2: Char,
         surroundingRight2: Char,
         surroundingTop2: Char,
-        surroundingBottom2: Char,
+        surroundingBottom2: Char
     ): Char? {
         val mask1 = getCharMask(char1, MASK_CROSS)
         val mask2 = getCharMask(char2, MASK_CROSS)
 
         val maskLeft =
-            if (surroundingLeft1 in LEFT_IN_CHARS || surroundingLeft2 in LEFT_IN_CHARS) MASK_LEFT else 0
+            if (surroundingLeft1 in LEFT_IN_CHARS || surroundingLeft2 in LEFT_IN_CHARS) {
+                MASK_LEFT
+            } else {
+                0
+            }
         val maskRight =
-            if (surroundingRight1 in RIGHT_IN_CHARS || surroundingRight2 in RIGHT_IN_CHARS) MASK_RIGHT else 0
+            if (surroundingRight1 in RIGHT_IN_CHARS || surroundingRight2 in RIGHT_IN_CHARS) {
+                MASK_RIGHT
+            } else {
+                0
+            }
         val maskTop =
-            if (surroundingTop1 in TOP_IN_CHARS || surroundingTop2 in TOP_IN_CHARS) MASK_TOP else 0
+            if (surroundingTop1 in TOP_IN_CHARS || surroundingTop2 in TOP_IN_CHARS) {
+                MASK_TOP
+            } else {
+                0
+            }
         val maskBottom =
-            if (surroundingBottom1 in BOTTOM_IN_CHARS || surroundingBottom2 in BOTTOM_IN_CHARS) MASK_BOTTOM else 0
+            if (surroundingBottom1 in BOTTOM_IN_CHARS || surroundingBottom2 in BOTTOM_IN_CHARS) {
+                MASK_BOTTOM
+            } else {
+                0
+            }
 
         val innerMask = mask1 or mask2
         val outerMask = maskLeft or maskRight or maskTop or maskBottom
@@ -549,7 +565,7 @@ internal object CrossingResources {
                     "$surroundingRight1:$surroundingRight2:${maskToString(maskRight)}",
                     "$surroundingTop1:$surroundingTop2:${maskToString(maskTop)}",
                     "$surroundingBottom1:$surroundingBottom2:${maskToString(maskBottom)}",
-                    "-> ${maskToString(outerMask)}",
+                    "-> ${maskToString(outerMask)}"
                 ).toString(),
                 maskToString(outerMask),
                 "->",

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -399,14 +399,113 @@ internal object CrossingResources {
         '╩' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_TOP),
         '╦' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_BOTTOM),
         '╬' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_VERTICAL),
+
+        // Complex (SINGLE, BOLD) combinations
+        '╼' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT),
+        '╾' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT),
+
+        '╽' to (MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+        '╿' to (MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+
+        '┚' to (MASK_SINGLE_LEFT or MASK_BOLD_TOP),
+        '┙' to (MASK_BOLD_LEFT or MASK_SINGLE_TOP),
+
+        '┒' to (MASK_SINGLE_LEFT or MASK_BOLD_BOTTOM),
+        '┑' to (MASK_BOLD_LEFT or MASK_SINGLE_BOTTOM),
+
+        '┨' to (MASK_SINGLE_LEFT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
+        '┦' to (MASK_SINGLE_LEFT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '┧' to (MASK_SINGLE_LEFT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '┥' to (MASK_BOLD_LEFT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '┩' to (MASK_BOLD_LEFT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '┪' to (MASK_BOLD_LEFT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '┖' to (MASK_SINGLE_RIGHT or MASK_BOLD_TOP),
+        '┕' to (MASK_BOLD_RIGHT or MASK_SINGLE_TOP),
+
+        '┎' to (MASK_SINGLE_RIGHT or MASK_BOLD_BOTTOM),
+        '┍' to (MASK_BOLD_RIGHT or MASK_SINGLE_BOTTOM),
+
+        '┠' to (MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
+        '┞' to (MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '┟' to (MASK_SINGLE_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '┝' to (MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '┡' to (MASK_BOLD_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '┢' to (MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '┷' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP),
+        '┶' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP),
+        '┵' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_TOP),
+
+        '┸' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP),
+        '┹' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP),
+        '┺' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_TOP),
+
+        '┯' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_BOTTOM),
+        '┭' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_BOTTOM),
+        '┮' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_BOTTOM),
+
+        '┰' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_BOTTOM),
+        '┱' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_BOTTOM),
+        '┲' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_BOTTOM),
+        
+        '┽' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '┾' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '╀' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '╁' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '╂' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
+        '┿' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '╃' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '╄' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '╅' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+        '╆' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+
+        '╇' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
+        '╈' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
+        '╉' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
+        '╊' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
+        
+        // Complex (SINGLE, DOUBLE) combinations
+        '╒' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_BOTTOM),
+        '╓' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_BOTTOM),
+        
+        '╕' to (MASK_DOUBLE_LEFT or MASK_SINGLE_BOTTOM),
+        '╖' to (MASK_SINGLE_LEFT or MASK_DOUBLE_BOTTOM),
+
+        '╘' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP),
+        '╙' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP),
+        
+        '╛' to (MASK_SINGLE_LEFT or MASK_SINGLE_TOP),
+        '╜' to (MASK_SINGLE_LEFT or MASK_DOUBLE_TOP),
+        
+        '╞' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '╟' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
+        
+        '╡' to (MASK_DOUBLE_LEFT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '╢' to (MASK_SINGLE_LEFT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
+        
+        '╤' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_BOTTOM),
+        '╥' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_BOTTOM),
+        
+        '╧' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP),
+        '╨' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP),
+        
+        '╪' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
+        '╫' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
+        
     )
 
     private val MASK_TO_CHAR_MAP =
         CHAR_TO_MASK_MAP.entries.associate { (key, value) -> value to key }
 
     init {
-        for ((key, value) in MASK_TO_CHAR_MAP) {
-            console.log(maskToString(key), value.toString())
+        if (Build.DEBUG) {
+            for ((key, value) in MASK_TO_CHAR_MAP) {
+                console.log(value.toString(), maskToString(key))
+            }
         }
     }
 
@@ -437,7 +536,7 @@ internal object CrossingResources {
         val innerMask = mask1 or mask2
         val outerMask = maskLeft or maskRight or maskTop or maskBottom
         val mask = innerMask and outerMask
-        
+
         if (Build.DEBUG) {
             console.log(
                 listOf(
@@ -468,5 +567,5 @@ internal object CrossingResources {
 
     private fun standardize(char: Char): Char = STANDARDIZED_CHARS[char] ?: char
 
-    private fun maskToString(mask: Int): String = mask.toString(2).padStart(4, '0')
+    private fun maskToString(mask: Int): String = mask.toString(2).padStart(12, '0')
 }

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -479,7 +479,7 @@ internal object CrossingResources {
         '╘' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP),
         '╙' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP),
 
-        '╛' to (MASK_SINGLE_LEFT or MASK_SINGLE_TOP),
+        '╛' to (MASK_DOUBLE_LEFT or MASK_SINGLE_TOP),
         '╜' to (MASK_SINGLE_LEFT or MASK_DOUBLE_TOP),
 
         '╞' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -4,6 +4,8 @@
 
 package mono.graphics.board
 
+import mono.environment.Build
+
 /**
  * An objects that defines resources for crossing.
  */
@@ -331,5 +333,140 @@ internal object CrossingResources {
             ?: SINGLE_CONNECTOR_CHAR_MAP["$standardizedChar2$standardizedChar1"]
     }
 
+    private const val MASK_SINGLE_LEFT = 0b0001
+    private const val MASK_SINGLE_RIGHT = 0b0010
+    private const val MASK_SINGLE_TOP = 0b0100
+    private const val MASK_SINGLE_BOTTOM = 0b1000
+    private const val MASK_SINGLE_HORIZONTAL = MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT
+    private const val MASK_SINGLE_VERTICAL = MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM
+    private const val MASK_SINGLE_CROSS = MASK_SINGLE_HORIZONTAL or MASK_SINGLE_VERTICAL
+
+    private const val MASK_BOLD_LEFT = MASK_SINGLE_LEFT shl 4
+    private const val MASK_BOLD_RIGHT = MASK_SINGLE_RIGHT shl 4
+    private const val MASK_BOLD_TOP = MASK_SINGLE_TOP shl 4
+    private const val MASK_BOLD_BOTTOM = MASK_SINGLE_BOTTOM shl 4
+    private const val MASK_BOLD_HORIZONTAL = MASK_SINGLE_HORIZONTAL shl 4
+    private const val MASK_BOLD_VERTICAL = MASK_SINGLE_VERTICAL shl 4
+    private const val MASK_BOLD_CROSS = MASK_SINGLE_CROSS shl 4
+
+    private const val MASK_DOUBLE_LEFT = MASK_SINGLE_LEFT shl 8
+    private const val MASK_DOUBLE_RIGHT = MASK_SINGLE_RIGHT shl 8
+    private const val MASK_DOUBLE_TOP = MASK_SINGLE_TOP shl 8
+    private const val MASK_DOUBLE_BOTTOM = MASK_SINGLE_BOTTOM shl 8
+    private const val MASK_DOUBLE_HORIZONTAL = MASK_SINGLE_HORIZONTAL shl 8
+    private const val MASK_DOUBLE_VERTICAL = MASK_SINGLE_VERTICAL shl 8
+    private const val MASK_DOUBLE_CROSS = MASK_SINGLE_CROSS shl 8
+
+    private const val MASK_LEFT = MASK_SINGLE_LEFT or MASK_BOLD_LEFT or MASK_DOUBLE_LEFT
+    private const val MASK_RIGHT = MASK_SINGLE_RIGHT or MASK_BOLD_RIGHT or MASK_DOUBLE_RIGHT
+    private const val MASK_TOP = MASK_SINGLE_TOP or MASK_BOLD_TOP or MASK_DOUBLE_TOP
+    private const val MASK_BOTTOM = MASK_SINGLE_BOTTOM or MASK_BOLD_BOTTOM or MASK_DOUBLE_BOTTOM
+    private const val MASK_CROSS = MASK_SINGLE_CROSS or MASK_BOLD_CROSS or MASK_DOUBLE_CROSS
+
+    private val CHAR_TO_MASK_MAP = mapOf(
+        '─' to MASK_SINGLE_HORIZONTAL,
+        '│' to MASK_SINGLE_VERTICAL,
+        '┘' to (MASK_SINGLE_LEFT or MASK_SINGLE_TOP),
+        '┐' to (MASK_SINGLE_LEFT or MASK_SINGLE_BOTTOM),
+        '┤' to (MASK_SINGLE_LEFT or MASK_SINGLE_VERTICAL),
+        '└' to (MASK_SINGLE_RIGHT or MASK_SINGLE_TOP),
+        '┌' to (MASK_SINGLE_RIGHT or MASK_SINGLE_BOTTOM),
+        '├' to (MASK_SINGLE_RIGHT or MASK_SINGLE_VERTICAL),
+        '┴' to (MASK_SINGLE_HORIZONTAL or MASK_SINGLE_TOP),
+        '┬' to (MASK_SINGLE_HORIZONTAL or MASK_SINGLE_BOTTOM),
+        '┼' to (MASK_SINGLE_HORIZONTAL or MASK_SINGLE_VERTICAL),
+
+        '━' to MASK_BOLD_HORIZONTAL,
+        '┃' to MASK_BOLD_VERTICAL,
+        '┛' to (MASK_BOLD_LEFT or MASK_BOLD_TOP),
+        '┓' to (MASK_BOLD_LEFT or MASK_BOLD_BOTTOM),
+        '┫' to (MASK_BOLD_LEFT or MASK_BOLD_VERTICAL),
+        '┗' to (MASK_BOLD_RIGHT or MASK_BOLD_TOP),
+        '┏' to (MASK_BOLD_RIGHT or MASK_BOLD_BOTTOM),
+        '┣' to (MASK_BOLD_RIGHT or MASK_BOLD_VERTICAL),
+        '┻' to (MASK_BOLD_HORIZONTAL or MASK_BOLD_TOP),
+        '┳' to (MASK_BOLD_HORIZONTAL or MASK_BOLD_BOTTOM),
+        '╋' to (MASK_BOLD_HORIZONTAL or MASK_BOLD_VERTICAL),
+
+        '═' to MASK_DOUBLE_HORIZONTAL,
+        '║' to MASK_DOUBLE_VERTICAL,
+        '╝' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_TOP),
+        '╗' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_BOTTOM),
+        '╣' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_VERTICAL),
+        '╚' to (MASK_DOUBLE_RIGHT or MASK_DOUBLE_TOP),
+        '╔' to (MASK_DOUBLE_RIGHT or MASK_DOUBLE_BOTTOM),
+        '╠' to (MASK_DOUBLE_RIGHT or MASK_DOUBLE_VERTICAL),
+        '╩' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_TOP),
+        '╦' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_BOTTOM),
+        '╬' to (MASK_DOUBLE_HORIZONTAL or MASK_DOUBLE_VERTICAL),
+    )
+
+    private val MASK_TO_CHAR_MAP =
+        CHAR_TO_MASK_MAP.entries.associate { (key, value) -> value to key }
+
+    init {
+        for ((key, value) in MASK_TO_CHAR_MAP) {
+            console.log(maskToString(key), value.toString())
+        }
+    }
+
+    fun getCrossingChar(
+        char1: Char,
+        surroundingLeft1: Char,
+        surroundingRight1: Char,
+        surroundingTop1: Char,
+        surroundingBottom1: Char,
+        char2: Char,
+        surroundingLeft2: Char,
+        surroundingRight2: Char,
+        surroundingTop2: Char,
+        surroundingBottom2: Char,
+    ): Char? {
+        val mask1 = getCharMask(char1, MASK_CROSS)
+        val mask2 = getCharMask(char2, MASK_CROSS)
+
+        val maskLeft =
+            if (surroundingLeft1 in LEFT_IN_CHARS || surroundingLeft2 in LEFT_IN_CHARS) MASK_LEFT else 0
+        val maskRight =
+            if (surroundingRight1 in RIGHT_IN_CHARS || surroundingRight2 in RIGHT_IN_CHARS) MASK_RIGHT else 0
+        val maskTop =
+            if (surroundingTop1 in TOP_IN_CHARS || surroundingTop2 in TOP_IN_CHARS) MASK_TOP else 0
+        val maskBottom =
+            if (surroundingBottom1 in BOTTOM_IN_CHARS || surroundingBottom2 in BOTTOM_IN_CHARS) MASK_BOTTOM else 0
+
+        val innerMask = mask1 or mask2
+        val outerMask = maskLeft or maskRight or maskTop or maskBottom
+        val mask = innerMask and outerMask
+        
+        if (Build.DEBUG) {
+            console.log(
+                listOf(
+                    "$char1:${maskToString(mask1)}",
+                    "$char2:${maskToString(mask2)}",
+                    "-> ${maskToString(innerMask)}"
+                ).toString(),
+                listOf(
+                    "$surroundingLeft1:$surroundingLeft2:${maskToString(maskLeft)}",
+                    "$surroundingRight1:$surroundingRight2:${maskToString(maskRight)}",
+                    "$surroundingTop1:$surroundingTop2:${maskToString(maskTop)}",
+                    "$surroundingBottom1:$surroundingBottom2:${maskToString(maskBottom)}",
+                    "-> ${maskToString(outerMask)}",
+                ).toString(),
+                maskToString(outerMask),
+                "->",
+                maskToString(mask),
+                MASK_TO_CHAR_MAP[mask].toString()
+            )
+        }
+        return MASK_TO_CHAR_MAP[mask]
+    }
+
+    private fun getCharMask(char: Char, mask: Int): Int {
+        val charMask = CHAR_TO_MASK_MAP[char] ?: 0
+        return charMask and mask
+    }
+
     private fun standardize(char: Char): Char = STANDARDIZED_CHARS[char] ?: char
+
+    private fun maskToString(mask: Int): String = mask.toString(2).padStart(4, '0')
 }

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -38,6 +38,7 @@ internal object CrossingResources {
 
     private val CONNECTABLE_CHARS = "─│┌└┐┘┬┴├┤┼".extendChars().flatMap { it.toList() }.toSet()
 
+    // TODO: Extend the list with complex combination chars.
     private val LEFT_IN_CHARS: Set<Char> = "─┌└┬┴├┼".extendChars().flatMap { it.toList() }.toSet()
     private val RIGHT_IN_CHARS: Set<Char> = "─┐┘┬┴┤┼".extendChars().flatMap { it.toList() }.toSet()
     private val TOP_IN_CHARS: Set<Char> = "│┌┐┬├┤┼".extendChars().flatMap { it.toList() }.toSet()
@@ -450,7 +451,7 @@ internal object CrossingResources {
         '┰' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_BOTTOM),
         '┱' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_BOTTOM),
         '┲' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_BOTTOM),
-        
+
         '┽' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
         '┾' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
         '╀' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_SINGLE_BOTTOM),
@@ -467,35 +468,34 @@ internal object CrossingResources {
         '╈' to (MASK_BOLD_LEFT or MASK_BOLD_RIGHT or MASK_SINGLE_TOP or MASK_BOLD_BOTTOM),
         '╉' to (MASK_BOLD_LEFT or MASK_SINGLE_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
         '╊' to (MASK_SINGLE_LEFT or MASK_BOLD_RIGHT or MASK_BOLD_TOP or MASK_BOLD_BOTTOM),
-        
+
         // Complex (SINGLE, DOUBLE) combinations
         '╒' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_BOTTOM),
         '╓' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_BOTTOM),
-        
+
         '╕' to (MASK_DOUBLE_LEFT or MASK_SINGLE_BOTTOM),
         '╖' to (MASK_SINGLE_LEFT or MASK_DOUBLE_BOTTOM),
 
         '╘' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP),
         '╙' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP),
-        
+
         '╛' to (MASK_SINGLE_LEFT or MASK_SINGLE_TOP),
         '╜' to (MASK_SINGLE_LEFT or MASK_DOUBLE_TOP),
-        
+
         '╞' to (MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
         '╟' to (MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
-        
+
         '╡' to (MASK_DOUBLE_LEFT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
         '╢' to (MASK_SINGLE_LEFT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
-        
+
         '╤' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_BOTTOM),
         '╥' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_BOTTOM),
-        
+
         '╧' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP),
         '╨' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP),
-        
+
         '╪' to (MASK_DOUBLE_LEFT or MASK_DOUBLE_RIGHT or MASK_SINGLE_TOP or MASK_SINGLE_BOTTOM),
-        '╫' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM),
-        
+        '╫' to (MASK_SINGLE_LEFT or MASK_SINGLE_RIGHT or MASK_DOUBLE_TOP or MASK_DOUBLE_BOTTOM)
     )
 
     private val MASK_TO_CHAR_MAP =

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
@@ -45,7 +45,7 @@ class MonoBoard(private val unitSize: Size = STANDARD_UNIT_SIZE) {
             crossingPoints += board.fill(position, bitmap, highlight)
         }
 
-        drawCrossingPoints(crossingPoints, highlight)
+        drawCrossingPoints2(crossingPoints, highlight)
     }
 
     private fun drawCrossingPoints(crossingPoints: List<CrossPoint>, highlight: Highlight) {
@@ -94,6 +94,31 @@ class MonoBoard(private val unitSize: Size = STANDARD_UNIT_SIZE) {
                 directionChar = directionMap[directionMark] ?: charPoint.directionChar,
                 highlight = highlight
             )
+        }
+    }
+
+    private fun drawCrossingPoints2(crossingPoints: List<CrossPoint>, highlight: Highlight) {
+        for (charPoint in crossingPoints) {
+            val left = charPoint.left
+            val top = charPoint.top
+            val currentPixel = get(left, top)
+            val crossingChar = CrossingResources.getCrossingChar(
+                char1 = charPoint.visualChar,
+                surroundingLeft1 = charPoint.leftChar,
+                surroundingRight1 = charPoint.rightChar,
+                surroundingTop1 = charPoint.topChar,
+                surroundingBottom1 = charPoint.bottomChar,
+                char2 = get(left, top).visualChar,
+                surroundingLeft2 = get(left - 1, top).directionChar,
+                surroundingRight2 = get(left + 1, top).directionChar,
+                surroundingTop2 = get(left, top - 1).directionChar,
+                surroundingBottom2 = get(left, top + 1).directionChar
+            )
+            if (crossingChar != null) {
+                currentPixel.set(crossingChar, crossingChar, highlight)
+            } else {
+                currentPixel.set(charPoint.visualChar, charPoint.directionChar, highlight)
+            }
         }
     }
 


### PR DESCRIPTION
Instead of having a database of combinable characters, the new algorithm uses bit-wise to detect the crossing characters.

A character is converted into 12-bit number of 3 groups of format (single, bold, double).
Each group contains 4 bits representing 4 directions: [bottom, top, right, left]
```
 DOUBLE          SINGLE             
╠═══════╣       ├───────┤  B: Bottom
┌─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┐  T: Top   
│B│T│R│L│B│T│R│L│B│T│R│L│  R: Right 
└─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┘  L: Left  
        ┣━━━━━━━┫                   
          BOLD                      
```
- 2 crossing characters at a cell will be combined with `or` operator (inner_mask).
- Equivalent 4 surrounding characters of the 2 are also combined with `or` operator (outer_mask).
- Then, `inner_mask` combines with `outer_mask` with `and` operator.
- The result will be decoded into characters again and that is the crossing point character.

This also allows complex combinations of single-bold and single-double chars to connect

```
╓───────┒
║       ┃
╟───────┨
║       ┃
╙───────┚
```

TODO: new complex combination characters (such as `╓`) are not used as possible surrounding yet.