### PR TITLE
Fix line anchor char is overriden when overlapping lines

### DIFF
--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -533,7 +533,16 @@ internal object CrossingResources {
 
         val innerMask = maskUpper or maskLower
         val outerMask = maskLeft or maskRight or maskTop or maskBottom
-        val mask = innerMask and outerMask
+
+        val outerDirectionCount = countMask(outerMask) / 3 // 3 is the number of format.
+        val mask = if (countMask(maskUpper) > outerDirectionCount) {
+            // If the upper char has more directions than the outer directions, use the inner mask
+            // only. This happens when the upper char is a sole char with no or not enough adjacent
+            // chars. For example, use ├ for the line anchor.
+            innerMask
+        } else {
+            innerMask and outerMask
+        }
 
         if (Build.DEBUG) {
             console.log(
@@ -576,5 +585,18 @@ internal object CrossingResources {
         val allDirectionsMask =
             ((mask shl 8) or (mask shl 4) or mask or (mask shr 4) or (mask shr 8)) and MASK_CROSS
         return MASK_CROSS xor allDirectionsMask
+    }
+
+    /**
+     * Counts the number of bits that are set to 1 in the given mask.
+     */
+    private fun countMask(mask: Int): Int {
+        var count = 0
+        var m = mask
+        while (m != 0) {
+            count += m and 1
+            m = m shr 1
+        }
+        return count
     }
 }


### PR DESCRIPTION
With this test case
```
{"shapes":[{"type":"L","i":"02-AAeP9cfntWDQPlfHwGZgIcScyLj","idtemp":true,"v":-835964721,"ps":"H|46|21","pe":"V|89|21","jps":["46|21","89|21"],"e":{"su":"S1","ase":true,"asu":"A6","aee":true,"aeu":"A1","du":"1|0|0"},"em":false},{"type":"L","i":"02-AAeP9cfklJ5FYqo9J6KY3la-Ecx","idtemp":true,"v":2000417950,"ps":"H|62|21","pe":"V|89|21","jps":["62|21","89|21"],"e":{"su":"S1","ase":true,"asu":"A6","aee":true,"aeu":"A1","du":"1|0|0"},"em":false}],"connectors":[]}
```
Before
```
├──────────────────────────────────────────▶
```
After
```
├───────────────┼──────────────────────────▶
```