### PR TITLE
Correct getting value from value getter instead of from valueInternal

### DIFF
--- a/monosketch-svelte/src/lib/libs/flow/flow.ts
+++ b/monosketch-svelte/src/lib/libs/flow/flow.ts
@@ -131,7 +131,9 @@ export class Flow<T> {
             parent.addInternalObserver(
                 flow,
                 new SimpleObserver(() => {
-                    const values = flows.map((flow) => flow.valueInternal);
+                    // TODO: Getting value with `.value` can increase the computation cost since the value is computed
+                    //  from its parent flows. We should consider optimizing this.
+                    const values = flows.map((flow) => flow.value);
                     if (values.includes(undefined)) {
                         // Only update the value when all values are available.
                         return;


### PR DESCRIPTION
`valueInternal` is `undefined` if the flow is immutable (due to `.immutable()` or `.map()` or created by `combineX`). 

This can increase the computation cost since the value is calculated from its parents' value every time. 
Think a way to optimise.