### PR TITLE
Update platform detection

### DIFF
--- a/monosketch-svelte/src/lib/mono/common/platform.ts
+++ b/monosketch-svelte/src/lib/mono/common/platform.ts
@@ -1,5 +1,5 @@
 export const isCommandKeySupported = (): boolean => {
-    return navigator.userAgent.includes('Mac')
+    return navigator.userAgent.includes('Mac');
 };
 
 export const isCommandKeyOn = (e: KeyboardEvent): boolean => {

--- a/monosketch-svelte/src/lib/mono/common/platform.ts
+++ b/monosketch-svelte/src/lib/mono/common/platform.ts
@@ -1,6 +1,5 @@
 export const isCommandKeySupported = (): boolean => {
-    // TODO: Resolve platform deprecated.
-    return navigator.platform.startsWith('Mac');
+    return navigator.userAgent.includes('Mac')
 };
 
 export const isCommandKeyOn = (e: KeyboardEvent): boolean => {


### PR DESCRIPTION
`Navigator.platform` is deprecated. We can use `Navigator.userAgentData` or `Navigator.userAgent` to get the platform data. 

But since `userAgentData` is [not supported on some browsers](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData#browser_compatibility), I suggest we should use [userAgent](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) instead.

For example, the `userAgent` value for some browser on MacOS looks like this:
```
// Chrome
'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'

// Safari
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15" = $1

// Firefox
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0" 
```

**Limitations**:
While [userAgent](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) isn't exactly used for OS detection like [platform](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform), it's acceptable in this scenario since most modern browsers include the operating system information in the [userAgent](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) string.