### PR TITLE
Update Key Command Handling

### DIFF
--- a/monosketch-svelte/src/lib/mono/keycommand/controller.ts
+++ b/monosketch-svelte/src/lib/mono/keycommand/controller.ts
@@ -1,5 +1,5 @@
 import { Flow } from '$libs/flow';
-import { type KeyCommand, KeyCommandType } from './interface';
+import { getKeyFromEvent, type KeyCommand, KeyCommandType } from './interface';
 import { getCommandByType, getCommandByKey } from './keycommands';
 import { DEBUG_MODE } from '../build_environment';
 import { isCommandKeyOn } from '../common/platform';
@@ -17,10 +17,13 @@ export class KeyCommandController {
     }
 
     private updateKeyCommand = (e: KeyboardEvent) => {
-        // TODO: Resolve keyCode deprecated.
+        const keyMap = getKeyFromEvent(e);
+        if (!keyMap) {
+            return;
+        }
         const keyCommand =
             e.target === this.body
-                ? getCommandByKey(e.keyCode, isCommandKeyOn(e), e.shiftKey)
+                ? getCommandByKey(keyMap, isCommandKeyOn(e), e.shiftKey)
                 : getCommandByType(KeyCommandType.IDLE);
 
         if (!keyCommand.isKeyEventPropagationAllowed) {

--- a/monosketch-svelte/src/lib/mono/keycommand/interface.ts
+++ b/monosketch-svelte/src/lib/mono/keycommand/interface.ts
@@ -2,24 +2,33 @@
  * An object to contains all handling key-codes.
  */
 export class Key {
-    static readonly ESC = 27;
-    static readonly SHIFT = 16;
-    static readonly ENTER = 13;
-    static readonly BACKSPACE = 8;
-    static readonly DELETE = 46;
-    static readonly ARROW_LEFT = 37;
-    static readonly ARROW_UP = 38;
-    static readonly ARROW_RIGHT = 39;
-    static readonly ARROW_DOWN = 40;
-    static readonly A = 65;
-    static readonly C = 67;
-    static readonly D = 68;
-    static readonly L = 76;
-    static readonly R = 82;
-    static readonly T = 84;
-    static readonly V = 86;
-    static readonly X = 88;
-    static readonly Z = 90;
+    static readonly ESC: KeyMap = { key: ['Escape'], keyCode: 27 };
+    static readonly SHIFT: KeyMap = { key: ['Shift'], keyCode: 16 };
+    static readonly ENTER: KeyMap = { key: ['Enter'], keyCode: 13 };
+    static readonly BACKSPACE: KeyMap = { key: ['Backspace'], keyCode: 8 };
+    static readonly DELETE: KeyMap = { key: ['Delete'], keyCode: 46 };
+    static readonly ARROW_LEFT: KeyMap = { key: ['ArrowLeft'], keyCode: 37 };
+    static readonly ARROW_UP: KeyMap = { key: ['ArrowUp'], keyCode: 38 };
+    static readonly ARROW_RIGHT: KeyMap = { key: ['ArrowRight'], keyCode: 39 };
+    static readonly ARROW_DOWN: KeyMap = { key: ['ArrowDown'], keyCode: 40 };
+    static readonly A: KeyMap = { key: ['a', 'A'], keyCode: 65 };
+    static readonly C: KeyMap = { key: ['c', 'C'], keyCode: 67 };
+    static readonly D: KeyMap = { key: ['d', 'D'], keyCode: 68 };
+    static readonly L: KeyMap = { key: ['l', 'L'], keyCode: 76 };
+    static readonly R: KeyMap = { key: ['r', 'R'], keyCode: 82 };
+    static readonly T: KeyMap = { key: ['t', 'T'], keyCode: 84 };
+    static readonly V: KeyMap = { key: ['v', 'V'], keyCode: 86 };
+    static readonly X: KeyMap = { key: ['x', 'X'], keyCode: 88 };
+    static readonly Z: KeyMap = { key: ['z', 'Z'], keyCode: 90 };
+}
+
+export function getKeyFromEvent(e: KeyboardEvent): KeyMap | undefined {
+    return Object.values(Key).find(keyMap => keyMap.key.includes(e.key));
+}
+
+export interface KeyMap {
+    key: string[]; // Using array to support multiple key variations (e.g. 'a' and 'A')
+    keyCode: number;
 }
 
 interface MetaKeyState {
@@ -74,7 +83,7 @@ export enum KeyCommandType {
 
 export interface KeyCommand {
     command: KeyCommandType;
-    keyCodes: Key[];
+    key: KeyMap[];
     commandKeyState: MetaKeyState;
     shiftKeyState: MetaKeyState;
     isKeyEventPropagationAllowed: boolean;

--- a/monosketch-svelte/src/lib/mono/keycommand/keycommands.ts
+++ b/monosketch-svelte/src/lib/mono/keycommand/keycommands.ts
@@ -1,8 +1,8 @@
-import { Key, type KeyCommand, KeyCommandType, MetaKeyState } from './interface';
+import { Key, type KeyCommand, KeyCommandType, type KeyMap, MetaKeyState } from './interface';
 
 const KeyCommandOptionsDefaults: KeyCommand = {
     command: KeyCommandType.IDLE,
-    keyCodes: [],
+    key: [],
     commandKeyState: MetaKeyState.ANY,
     shiftKeyState: MetaKeyState.ANY,
     isKeyEventPropagationAllowed: true,
@@ -18,46 +18,46 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.SELECT_ALL,
-        keyCodes: [Key.A],
+        key: [Key.A],
         commandKeyState: MetaKeyState.ON,
         isKeyEventPropagationAllowed: false,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.DESELECTION,
-        keyCodes: [Key.ESC],
+        key: [Key.ESC],
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.DELETE,
-        keyCodes: [Key.DELETE, Key.BACKSPACE],
+        key: [Key.DELETE, Key.BACKSPACE],
     },
 
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.MOVE_LEFT,
-        keyCodes: [Key.ARROW_LEFT],
+        key: [Key.ARROW_LEFT],
         shiftKeyState: MetaKeyState.OFF,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.MOVE_UP,
-        keyCodes: [Key.ARROW_UP],
+        key: [Key.ARROW_UP],
         shiftKeyState: MetaKeyState.OFF,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.MOVE_RIGHT,
-        keyCodes: [Key.ARROW_RIGHT],
+        key: [Key.ARROW_RIGHT],
         shiftKeyState: MetaKeyState.OFF,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.MOVE_DOWN,
-        keyCodes: [Key.ARROW_DOWN],
+        key: [Key.ARROW_DOWN],
         shiftKeyState: MetaKeyState.OFF,
         isRepeatable: true,
     },
@@ -65,28 +65,28 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.FAST_MOVE_LEFT,
-        keyCodes: [Key.ARROW_LEFT],
+        key: [Key.ARROW_LEFT],
         shiftKeyState: MetaKeyState.ON,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.FAST_MOVE_UP,
-        keyCodes: [Key.ARROW_UP],
+        key: [Key.ARROW_UP],
         shiftKeyState: MetaKeyState.ON,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.FAST_MOVE_RIGHT,
-        keyCodes: [Key.ARROW_RIGHT],
+        key: [Key.ARROW_RIGHT],
         shiftKeyState: MetaKeyState.ON,
         isRepeatable: true,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.FAST_MOVE_DOWN,
-        keyCodes: [Key.ARROW_DOWN],
+        key: [Key.ARROW_DOWN],
         shiftKeyState: MetaKeyState.ON,
         isRepeatable: true,
     },
@@ -94,17 +94,17 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.ADD_RECTANGLE,
-        keyCodes: [Key.R],
+        key: [Key.R],
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.ADD_TEXT,
-        keyCodes: [Key.T],
+        key: [Key.T],
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.ADD_LINE,
-        keyCodes: [Key.L],
+        key: [Key.L],
     },
 
     {
@@ -114,27 +114,27 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.SELECTION_MODE,
-        keyCodes: [Key.V],
+        key: [Key.V],
         commandKeyState: MetaKeyState.OFF,
     },
 
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.COPY,
-        keyCodes: [Key.C],
+        key: [Key.C],
         commandKeyState: MetaKeyState.ON,
         shiftKeyState: MetaKeyState.OFF,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.CUT,
-        keyCodes: [Key.X],
+        key: [Key.X],
         commandKeyState: MetaKeyState.ON,
     },
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.DUPLICATE,
-        keyCodes: [Key.D],
+        key: [Key.D],
         commandKeyState: MetaKeyState.ON,
         isKeyEventPropagationAllowed: false,
     },
@@ -142,7 +142,7 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.COPY_TEXT,
-        keyCodes: [Key.C],
+        key: [Key.C],
         commandKeyState: MetaKeyState.ON,
         shiftKeyState: MetaKeyState.ON,
         isKeyEventPropagationAllowed: false,
@@ -151,7 +151,7 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.UNDO,
-        keyCodes: [Key.Z],
+        key: [Key.Z],
         commandKeyState: MetaKeyState.ON,
         shiftKeyState: MetaKeyState.OFF,
         isRepeatable: true,
@@ -159,7 +159,7 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.REDO,
-        keyCodes: [Key.Z],
+        key: [Key.Z],
         commandKeyState: MetaKeyState.ON,
         shiftKeyState: MetaKeyState.ON,
         isRepeatable: true,
@@ -168,7 +168,7 @@ const KeyCommands: KeyCommand[] = [
     {
         ...KeyCommandOptionsDefaults,
         command: KeyCommandType.SHIFT_KEY,
-        keyCodes: [Key.SHIFT],
+        key: [Key.SHIFT],
     },
 ];
 
@@ -181,7 +181,7 @@ function initKeyToKeyCommandMap() {
     }
 
     for (const keyCommand of KeyCommands) {
-        for (const keyCode of keyCommand.keyCodes) {
+        for (const keyCode of keyCommand.key) {
             const keyCommands = KeyCodeToKeyCommandMap.get(keyCode);
             if (keyCommands) {
                 keyCommands.push(keyCommand);
@@ -193,7 +193,7 @@ function initKeyToKeyCommandMap() {
 }
 
 export function getCommandByKey(
-    key: Key,
+    key: KeyMap,
     hasCommandKey: boolean,
     hasShiftKey: boolean,
 ): KeyCommand {


### PR DESCRIPTION
This pull request updates the key command handling to replace the deprecated `event.keyCode`. The changes include:

- Refactoring the `Key` class to use `KeyMap` objects for better key event handling.
- Introducing a new `getKeyFromEvent` function to map keyboard events to `KeyMap` objects.
- Updating the `KeyCommandController` and related classes to use the new key mapping.
- Modifying the `KeyCommands` to use `KeyMap` instead of key codes directly.

These improvements enhance the maintainability and extendability of the key command handling mechanism while replacing the deprecated `event.keyCode`.