### PR TITLE
Event Emission from viewmodel to Event Manager and Rename Project Flow Update

### DIFF
--- a/monosketch-svelte/src/lib/mono/action-manager/one-time-actions.ts
+++ b/monosketch-svelte/src/lib/mono/action-manager/one-time-actions.ts
@@ -76,7 +76,7 @@ export const OneTimeAction = {
     Idle: { type: 'Idle' } as OneTimeActionType,
 
     ProjectAction: {
-        RenameCurrentProject: (newName: string) => ({ type: 'RenameCurrentProject', newName }),
+        RenameCurrentProject: (newName: string): OneTimeActionType => ({ type: 'RenameCurrentProject', newName }),
         NewProject: { type: 'NewProject' } as OneTimeActionType,
         ExportSelectedShapes: { type: 'ExportSelectedShapes' } as OneTimeActionType,
         SwitchProject: (projectId: string): OneTimeActionType => ({ type: 'SwitchProject', projectId }),

--- a/monosketch-svelte/src/lib/ui/modal/common/NoBackgroundModal.svelte
+++ b/monosketch-svelte/src/lib/ui/modal/common/NoBackgroundModal.svelte
@@ -7,6 +7,7 @@ dismiss the modal correctly.
 <script lang="ts">
 import { onMount } from 'svelte';
 
+export let onSubmit: () => void = () => {};
 export let onDismiss: () => void;
 export let left: number = 0;
 export let top: number = 0;
@@ -27,6 +28,8 @@ onMount(() => {
 function onKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
         dismiss();
+    } else if (event.key === 'Enter') {
+        submit();
     }
 }
 
@@ -59,6 +62,12 @@ function onFocusOut() {
 
 function dismiss() {
     checkbox = null;
+    onDismiss();
+}
+
+function submit() {
+    checkbox = null;
+    onSubmit();
     onDismiss();
 }
 

--- a/monosketch-svelte/src/lib/ui/modal/rename-project/RenameProjectModal.svelte
+++ b/monosketch-svelte/src/lib/ui/modal/rename-project/RenameProjectModal.svelte
@@ -14,10 +14,14 @@ $: left = model.targetBounds.left;
 $: top = model.targetBounds.top + model.targetBounds.height + 6;
 
 function onDismiss() {
+    modalViewModel.renamingProjectModalStateFlow.value = null;
+}
+
+function onSubmit() {
     if (name) {
         projectDataViewModel.setProjectName(model.id, name);
     }
-    projectDataViewModel.setRenamingProject('');
+    projectDataViewModel.setRenamingProject(model.id, name);
     modalViewModel.renamingProjectModalStateFlow.value = null;
 }
 
@@ -29,6 +33,6 @@ onMount(() => {
 });
 </script>
 
-<NoBackgroundModal {onDismiss} {left} {top} width="{180}">
+<NoBackgroundModal {onDismiss} {onSubmit} {left} {top} width="{180}">
     <ProjectNameTextField bind:name />
 </NoBackgroundModal>


### PR DESCRIPTION
**Changes Summary:**

1. Event Emission from `viewmodel.ts` to Event Manager:

     - Events are now emitted from `viewmodel.ts` to the Event Manager. Since I’m still getting familiar with the codebase, I'm not entirely sure if this is the best approach yet, but it's a start. Let me know if my implementation looks correct or if there’s a better way to handle this.

2. Rename Project Flow Update:

     - Added an `onSubmit` event to the `NoBackgroundModal`, which is now bound to the Enter key. This change allows users to submit the new project name by pressing Enter, while pressing ESC will cancel the renaming process.

     - Why do I do that? While testing the existing rename flow, I found it a bit confusing. Specifically, when the `RenameProjectModal` popped up, pressing ESC or clicking outside the modal would dismiss it, but the new project name would still be updated. Meanwhile, pressing Enter didn’t do anything at all. In most UI flows, ESC should cancel the action without making changes, and Enter should confirm it. That’s why I added the `onSubmit` method. Now, pressing Enter submits the new name and updates the project name, while ESC properly cancels without making any changes. This update should make the renaming process more intuitive and predictable.