### PR TITLE
Fix Tailwind CSS bundling by merging into main.css

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -11,9 +11,7 @@
           name="viewport"/>
     <title>Mono Sketch</title>
 
-    <!-- Tailwind CSS (utility classes) -->
-    <link href="tailwind.css" rel="stylesheet"/>
-    <!-- SCSS compiled styles (components & theme) -->
+    <!-- Combined CSS (Tailwind + SCSS) -->
     <link href="main.css" rel="stylesheet"/>
 </head>
 

--- a/tailwind.gradle
+++ b/tailwind.gradle
@@ -43,8 +43,44 @@ task compileTailwind(type: Exec) {
     outputs.file("${buildDir}/processedResources/js/main/tailwind.css")
 }
 
-// Make sure Tailwind compiles before resources are processed
-processResources.dependsOn(compileTailwind)
+// Merge Tailwind CSS into main.css after both are compiled
+task mergeTailwindCss {
+    description = 'Merge Tailwind CSS into main.css'
+    group = 'build'
+
+    dependsOn compileTailwind, compileSass
+
+    doLast {
+        def outputDir = file("${buildDir}/processedResources/js/main")
+        def tailwindFile = file("${outputDir}/tailwind.css")
+        def mainCssFile = file("${outputDir}/main.css")
+        def tempFile = file("${outputDir}/main.css.temp")
+
+        if (tailwindFile.exists() && mainCssFile.exists()) {
+            // Create temp file with Tailwind first, then main.css content
+            tempFile.withWriter { writer ->
+                writer.write(tailwindFile.text)
+                writer.write('\n')
+                writer.write(mainCssFile.text)
+            }
+
+            // Replace main.css with merged content
+            mainCssFile.delete()
+            tempFile.renameTo(mainCssFile)
+
+            // Remove standalone tailwind.css
+            tailwindFile.delete()
+
+            logger.lifecycle("Merged tailwind.css into main.css")
+        }
+    }
+}
+
+// Make sure Tailwind compiles before SASS
+compileSass.dependsOn(compileTailwind)
+
+// Make sure merge happens before resources are processed
+processResources.dependsOn(mergeTailwindCss)
 
 // Run Tailwind after npm install (handled by Kotlin/JS plugin)
 compileTailwind.shouldRunAfter(tasks.findByName('kotlinNpmInstall'))


### PR DESCRIPTION
Modify the build process to merge tailwind.css into main.css after compilation. This ensures the release script only needs to handle a single CSS file instead of maintaining two separate stylesheets.

Changes:
- Add mergeTailwindCss Gradle task that concatenates compiled Tailwind and SASS
- Update index.html to reference only main.css
- Tailwind utilities now load before SASS styles in the merged output